### PR TITLE
chore: enable prerelease

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  prerelease: auto
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'


### PR DESCRIPTION
Enable the prerelease feature to ensure the prerelease release doesn't go public registry.

Doc: https://goreleaser.com/customization/release/
