### PR TITLE
resource/schema: handle case the resource not in config

### DIFF
--- a/internal/provider/atlas_schema_resource.go
+++ b/internal/provider/atlas_schema_resource.go
@@ -217,6 +217,9 @@ func (r *AtlasSchemaResource) ModifyPlan(ctx context.Context, req resource.Modif
 		return
 	}
 	if state == nil || state.HCL.Value == "" {
+		if plan == nil {
+			return
+		}
 		if plan.URL.IsUnknown() {
 			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("url"))
 			return


### PR DESCRIPTION
If the resource not in the config, terraform will generate the empty plan, which cause the plugin to crash.