### PR TITLE
schema/resource: update applySchema to use CLI-base

### DIFF
--- a/internal/atlas/atlas_models.go
+++ b/internal/atlas/atlas_models.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"ariga.io/atlas/sql/sqlcheck"
+	"ariga.io/atlas/sql/sqlclient"
 )
 
 type (
@@ -95,5 +96,30 @@ type (
 
 		// Files reports. Non-empty in case there are findings.
 		Files []*FileReport `json:"Files,omitempty"`
+	}
+	// StmtError groups a statement with its execution error.
+	StmtError struct {
+		Stmt string `json:"Stmt,omitempty"` // SQL statement that failed.
+		Text string `json:"Text,omitempty"` // Error message as returned by the database.
+	}
+	// Env holds the environment information.
+	Env struct {
+		Driver string         `json:"Driver,omitempty"` // Driver name.
+		URL    *sqlclient.URL `json:"URL,omitempty"`    // URL to dev database.
+		Dir    string         `json:"Dir,omitempty"`    // Path to migration directory.
+	}
+	// Changes represents a list of changes that are pending or applied.
+	Changes struct {
+		Applied []string   `json:"Applied,omitempty"` // SQL changes applied with success
+		Pending []string   `json:"Pending,omitempty"` // SQL changes that were not applied
+		Error   *StmtError `json:"Error,omitempty"`   // Error that occurred during applying
+	}
+	// SchemaApply contains a summary of a 'schema apply' execution on a database.
+	SchemaApply struct {
+		Env
+		Changes Changes `json:"Changes,omitempty"`
+		// General error that occurred during execution.
+		// e.g., when committing or rolling back a transaction.
+		Error string `json:"Error,omitempty"`
 	}
 )

--- a/internal/atlas/atlas_test.go
+++ b/internal/atlas/atlas_test.go
@@ -103,6 +103,109 @@ func Test_MigrateStatus(t *testing.T) {
 	}
 }
 
+func Test_SchemaApply(t *testing.T) {
+	f, err := os.CreateTemp("", "sqlite-test")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	u := fmt.Sprintf("sqlite://%s?_fk=1", f.Name())
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	c, err := atlas.NewClient(context.Background(), wd, "atlas")
+	require.NoError(t, err)
+
+	s1 := `
+	-- create table "users
+	CREATE TABLE users(
+		id int NOT NULL,
+		name varchar(100) NULL,
+		PRIMARY KEY(id)
+	);
+	`
+	to, clean, err := atlas.TempFile(s1, "sql")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, clean())
+	}()
+	_, err = c.SchemaApply(context.Background(), &atlas.SchemaApplyParams{
+		URL:    u,
+		To:     to,
+		DevURL: "sqlite://file?_fk=1&cache=shared&mode=memory",
+	})
+	require.NoError(t, err)
+
+	s2 := s1 + `
+	-- create table "blog_posts"
+	CREATE TABLE blog_posts(
+		id int NOT NULL,
+		title varchar(100) NULL,
+		body text NULL,
+		author_id int NULL,
+		PRIMARY KEY(id),
+		CONSTRAINT author_fk FOREIGN KEY(author_id) REFERENCES users(id)
+	);`
+	to, clean2, err := atlas.TempFile(s2, "sql")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, clean2())
+	}()
+	_, err = c.SchemaApply(context.Background(), &atlas.SchemaApplyParams{
+		URL:    u,
+		To:     to,
+		DevURL: "sqlite://file?_fk=1&cache=shared&mode=memory",
+	})
+	require.NoError(t, err)
+
+	s, err := c.SchemaInspect(context.Background(), &atlas.SchemaInspectParams{
+		URL: u,
+	})
+	require.NoError(t, err)
+	require.Equal(t, `table "users" {
+  schema = schema.main
+  column "id" {
+    null = false
+    type = int
+  }
+  column "name" {
+    null = true
+    type = varchar
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+table "blog_posts" {
+  schema = schema.main
+  column "id" {
+    null = false
+    type = int
+  }
+  column "title" {
+    null = true
+    type = varchar
+  }
+  column "body" {
+    null = true
+    type = text
+  }
+  column "author_id" {
+    null = true
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "author_fk" {
+    columns     = [column.author_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+}
+schema "main" {
+}
+`, s)
+}
+
 func tempSchemas(t *testing.T, schemas ...string) {
 	c, err := sqlclient.Open(context.Background(), mysqlURL)
 	if err != nil {

--- a/internal/provider/atlas_schema_resource.go
+++ b/internal/provider/atlas_schema_resource.go
@@ -275,7 +275,7 @@ func PrintPlanSQL(ctx context.Context, c *atlas.Client, data *AtlasSchemaResourc
 	}
 	defer func() {
 		if err := cleanup(); err != nil {
-			tflog.Debug(ctx, "failed to remove HCL file", map[string]interface{}{
+			tflog.Debug(ctx, "Failed to remove HCL file", map[string]interface{}{
 				"error": err,
 			})
 		}
@@ -293,8 +293,8 @@ func PrintPlanSQL(ctx context.Context, c *atlas.Client, data *AtlasSchemaResourc
 		URL:     data.URL.Value,
 	})
 	if err != nil {
-		diags.AddError("HCL Error",
-			fmt.Sprintf("Unable to parse HCL, got error: %s", err),
+		diags.AddError("Atlas Plan Error",
+			fmt.Sprintf("Unable to generate migration plan, got error: %s", err),
 		)
 		return
 	}
@@ -318,12 +318,14 @@ func (r *AtlasSchemaResource) applySchema(ctx context.Context, data *AtlasSchema
 	}
 	to, cleanup, err := data.handleHCL()
 	if err != nil {
-		diags.AddError("Apply Error", fmt.Sprintf("Failed to create HCL file, got error: %s", err))
+		diags.AddError("HCL Error",
+			fmt.Sprintf("Unable to create temporary file for HCL, got error: %s", err),
+		)
 		return
 	}
 	defer func() {
 		if err := cleanup(); err != nil {
-			tflog.Debug(ctx, "failed to remove HCL file", map[string]interface{}{
+			tflog.Debug(ctx, "Failed to remove HCL file", map[string]interface{}{
 				"error": err,
 			})
 		}
@@ -335,7 +337,9 @@ func (r *AtlasSchemaResource) applySchema(ctx context.Context, data *AtlasSchema
 		URL:     data.URL.Value,
 	})
 	if err != nil {
-		diags.AddError("Apply Error", fmt.Sprintf("Unable to apply changes, got error: %s", err))
+		diags.AddError("Apply Error",
+			fmt.Sprintf("Unable to apply changes, got error: %s", err),
+		)
 		return
 	}
 	return diags
@@ -345,13 +349,13 @@ func (r *AtlasSchemaResource) firstRunCheck(ctx context.Context, data *AtlasSche
 	to, cleanup, err := data.handleHCL()
 	if err != nil {
 		diags.AddError("HCL Error",
-			fmt.Sprintf("Unable to parse HCL, got error: %s", err),
+			fmt.Sprintf("Unable to create temporary file for HCL, got error: %s", err),
 		)
 		return
 	}
 	defer func() {
 		if err := cleanup(); err != nil {
-			tflog.Debug(ctx, "failed to remove HCL file", map[string]interface{}{
+			tflog.Debug(ctx, "Failed to remove HCL file", map[string]interface{}{
 				"error": err,
 			})
 		}
@@ -369,8 +373,8 @@ func (r *AtlasSchemaResource) firstRunCheck(ctx context.Context, data *AtlasSche
 		URL:     data.URL.Value,
 	})
 	if err != nil {
-		diags.AddError("HCL Error",
-			fmt.Sprintf("Unable to parse HCL, got error: %s", err),
+		diags.AddError("Atlas Plan Error",
+			fmt.Sprintf("Unable to generate migration plan, got error: %s", err),
 		)
 		return
 	}

--- a/internal/provider/atlas_schema_resource.go
+++ b/internal/provider/atlas_schema_resource.go
@@ -380,7 +380,7 @@ func (r *AtlasSchemaResource) firstRunCheck(ctx context.Context, data *AtlasSche
 	}
 	var causes []string
 	for _, c := range result.Changes.Pending {
-		if strings.HasPrefix(c, "DROP ") {
+		if strings.Contains(c, "DROP ") {
 			causes = append(causes, c)
 		}
 	}
@@ -392,7 +392,6 @@ func (r *AtlasSchemaResource) firstRunCheck(ctx context.Context, data *AtlasSche
 To learn how to add an existing database to a project, read:
 https://atlasgo.io/terraform-provider#working-with-an-existing-database`, strings.Join(causes, "\n- ")))
 	}
-
 	return
 }
 


### PR DESCRIPTION
No new feature, no breaking change. Just move internal API from Go-API to CLI-API.