### PR TITLE
resource/migration: fixed version warning when no change

### DIFF
--- a/internal/provider/atlas_migration_data_source.go
+++ b/internal/provider/atlas_migration_data_source.go
@@ -123,12 +123,12 @@ func (d *MigrationDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 	data.Status = types.String{Value: r.Status}
 	if r.Status == "PENDING" && r.Current == noMigration {
-		data.Current = types.String{Null: true}
+		data.Current = types.String{Value: ""}
 	} else {
 		data.Current = types.String{Value: r.Current}
 	}
 	if r.Status == "OK" && r.Next == latestVersion {
-		data.Next = types.String{Null: true}
+		data.Next = types.String{Value: ""}
 	} else {
 		data.Next = types.String{Value: r.Next}
 	}

--- a/internal/provider/atlas_migration_data_source_test.go
+++ b/internal/provider/atlas_migration_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccMigrationDataSource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.atlas_migration.hello", "id", "migrations?format=atlas"),
 					resource.TestCheckResourceAttr("data.atlas_migration.hello", "status", "PENDING"),
-					resource.TestCheckNoResourceAttr("data.atlas_migration.hello", "current"),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "current", ""),
 					resource.TestCheckResourceAttr("data.atlas_migration.hello", "next", "20221101163823"),
 					resource.TestCheckResourceAttr("data.atlas_migration.hello", "latest", "20221101165415"),
 				),

--- a/internal/provider/atlas_migration_resource.go
+++ b/internal/provider/atlas_migration_resource.go
@@ -187,7 +187,7 @@ func (r MigrationResource) ValidateConfig(ctx context.Context, req resource.Vali
 		return
 	}
 	resp.Diagnostics.Append(r.validateConfig(ctx, req.Config)...)
-	if !data.Version.IsUnknown() && data.Version.Value == "" {
+	if data.Version.IsNull() {
 		resp.Diagnostics.AddAttributeWarning(
 			path.Root("version"),
 			"version is unset",
@@ -224,7 +224,7 @@ func (r *MigrationResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 			resp.Diagnostics.Append(atlas.ErrorDiagnostic(err, "Failed to read migration status"))
 			return
 		}
-		if plan.Version.IsNull() {
+		if plan.Version.Value == "" {
 			v := report.LatestVersion()
 			plan.Version = types.String{Value: v, Null: v == ""}
 		}


### PR DESCRIPTION
The data source returns a Null value for the next/latest so that's why the resource complains about missing `version` attribute in the plan step. This fix set next/latest to an empty string, and change the warning logic only complain when the field is Null.

Before:
![Screenshot 2023-04-20 at 13 38 32](https://user-images.githubusercontent.com/12751435/233284937-dbb70eeb-c7dd-43ab-99be-4ff7012d123c.png)
After:
![Screenshot 2023-04-20 at 13 55 40](https://user-images.githubusercontent.com/12751435/233285058-812bd025-6559-4a4d-b5c4-d16b18c0139f.png)
