### PR TITLE
fix: use correct atlas-cli for linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,9 +29,7 @@ builds:
   binary: '{{ .ProjectName }}_v{{ .Version }}'
   hooks:
     post:
-      - curl "https://release.ariga.io/atlas/atlas-{{ .Os }}-{{ if eq .Os "darwin" }}amd64{{ else }}{{ .Arch }}{{ end }}{{ if eq .Os "linux" }}{{ end }}-latest{{ .Ext }}"
-        -o {{ dir .Path }}/atlas{{ .Ext }}
-        -A "Terraform-Provider-CI"
+      - ./scripts/atlas.sh {{ .Os }}-{{ .Arch }} {{ dir .Path }}/atlas{{ .Ext }}
 archives:
 - format: zip
   files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
   binary: '{{ .ProjectName }}_v{{ .Version }}'
   hooks:
     post:
-      - curl "https://release.ariga.io/atlas/atlas-{{ .Os }}-{{ if eq .Os "darwin" }}amd64{{ else }}{{ .Arch }}{{ end }}{{ if eq .Os "linux" }}-musl{{ end }}-latest{{ .Ext }}"
+      - curl "https://release.ariga.io/atlas/atlas-{{ .Os }}-{{ if eq .Os "darwin" }}amd64{{ else }}{{ .Arch }}{{ end }}{{ if eq .Os "linux" }}{{ end }}-latest{{ .Ext }}"
         -o {{ dir .Path }}/atlas{{ .Ext }}
         -A "Terraform-Provider-CI"
 archives:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -140,14 +140,24 @@ func (p *AtlasProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		resp.Diagnostics.AddError("Unable to find atlas-cli", err.Error())
 		return
 	}
-	tflog.Debug(ctx, "Found atlas-cli", map[string]any{
-		"path": atlasPath,
-	})
 	c, err := atlas.NewClient("", atlasPath)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create client", err.Error())
 		return
 	}
+	v, err := c.Version(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Check atlas version failure", err.Error())
+		return
+	}
+	version := fmt.Sprintf("%s-%s", v.Version, v.SHA)
+	if v.Canary {
+		version += "-canary"
+	}
+	tflog.Debug(ctx, "found atlas-cli", map[string]any{
+		"path":    atlasPath,
+		"version": version,
+	})
 	p.client = c
 
 	var model *AtlasProviderModel

--- a/scripts/atlas.sh
+++ b/scripts/atlas.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+curl -sSf https://atlasgo.sh | \
+  sh -s -- -y --no-install --platform $1 --output $2

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HOSTNAME=registry.terraform.io
 NAMESPACE=ariga


### PR DESCRIPTION
Before this fix, the terraform-provider for linux was bundle with an old version of atlas-cli, which cause the issue https://github.com/ariga/terraform-provider-atlas/issues/99.
```
atlas version v0.12.1-73a6187-canary
```

This PR changed to use `atlasgo.sh` to download the binary for correct platform and architecture, ensure single-source-of-trust URL.

Fix: #99 