### PR TITLE
atlas/schema: support `atlas.hcl` and variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,9 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
-	github.com/lib/pq v1.10.9
-	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.8.4
+	github.com/zclconf/go-cty v1.15.0
 	golang.org/x/mod v0.15.0
 )
 
@@ -72,7 +71,6 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.14.4 // indirect
 	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 	golang.org/x/net v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 ariga.io/atlas v0.25.1-0.20240725062027-d43199a66f6e h1:iplLa9n+wAZLPrYwCfhVb0XzY5bQI+rPf9gol73USMA=
 ariga.io/atlas v0.25.1-0.20240725062027-d43199a66f6e/go.mod h1:KPLc7Zj+nzoXfWshrcY1RwlOh94dsATQEy4UPrF2RkM=
-ariga.io/atlas-go-sdk v0.5.8-0.20240724040154-54fd5f09583c h1:19hIly8NuHPzYmQSu+0MO7AhtjZDnD2vme2BOhkzi0A=
-ariga.io/atlas-go-sdk v0.5.8-0.20240724040154-54fd5f09583c/go.mod h1:9Q+/04PVyJHUse1lEE9Kp6E18xj/6mIzaUTcWYSjSnQ=
 ariga.io/atlas-go-sdk v0.5.8-0.20240806151605-4999cdd98524 h1:7Jr3S8416WoySZQZKKxzHE2CmJ+VuYMo9QscAoHN7z0=
 ariga.io/atlas-go-sdk v0.5.8-0.20240806151605-4999cdd98524/go.mod h1:9Q+/04PVyJHUse1lEE9Kp6E18xj/6mIzaUTcWYSjSnQ=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
@@ -145,8 +143,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -216,8 +212,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8=
-github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zclconf/go-cty v1.15.0 h1:tTCRWxsexYUmtt/wVxgDClUe+uQusuI443uL6e+5sXQ=
+github.com/zclconf/go-cty v1.15.0/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/provider/atlas_schema_resource_test.go
+++ b/internal/provider/atlas_schema_resource_test.go
@@ -127,6 +127,118 @@ resource "atlas_schema" "testdb" {
 	})
 }
 
+func TestAccAtlasSchema_AtlasHCL(t *testing.T) {
+	tempSchemas(t, mysqlURL, "test")
+	var testAccActionConfigCreate = fmt.Sprintf(`
+resource "foo_mirror" "url" {
+	value = "%s"
+}
+data "atlas_schema" "market" {
+  dev_url = "%s"
+  src = <<-EOT
+	schema "test" {
+		charset = "utf8mb4"
+		collate = "utf8mb4_0900_ai_ci"
+	}
+	table "foo" {
+		schema = schema.test
+		column "id" {
+			null           = false
+			type           = int
+			auto_increment = true
+		}
+		primary_key {
+			columns = [column.id]
+		}
+	}
+	EOT
+}
+resource "atlas_schema" "testdb" {
+  hcl = data.atlas_schema.market.hcl
+	config = <<-HCL
+variable "url" {
+	type = string
+}
+env {
+	url = var.url
+}
+HCL
+	variables = jsonencode({
+		url = foo_mirror.url.result
+	})
+	dev_url = "%s"
+}
+`, mysqlURL, mysqlDevURL, mysqlDevURL)
+
+	var testAccActionConfigUpdate = fmt.Sprintf(`
+data "atlas_schema" "market" {
+  dev_url = "%s"
+  src = <<-EOT
+	schema "test" {
+		charset = "utf8mb4"
+		collate = "utf8mb4_0900_ai_ci"
+	}
+	table "foo" {
+		schema = schema.test
+		column "id" {
+			null           = false
+			type           = int
+			auto_increment = true
+		}
+		column "name" {
+			null = false
+			type = varchar(20)
+		}
+		primary_key {
+			columns = [column.id]
+		}
+	}
+	EOT
+}
+resource "atlas_schema" "testdb" {
+  hcl = data.atlas_schema.market.hcl
+  url = "%s"
+}
+`, mysqlDevURL, mysqlURL)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"foo": newFooProvider("foo", "mirror"),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("atlas_schema.testdb", "id", mysqlURLWithoutCreds),
+				),
+			},
+			{
+				Config: testAccActionConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("atlas_schema.testdb", "id", mysqlURLWithoutCreds),
+					func(s *terraform.State) error {
+						res := s.RootModule().Resources["atlas_schema.testdb"]
+						cli, err := sqlclient.Open(context.Background(), res.Primary.Attributes["url"])
+						if err != nil {
+							return err
+						}
+						realm, err := cli.InspectRealm(context.Background(), nil)
+						if err != nil {
+							return err
+						}
+
+						if realm.Schemas[0].Tables[0].Columns[1].Name != "name" {
+							return fmt.Errorf("expected database state to have column \"name\" but got: %s", realm.Schemas[0].Tables[0].Columns[1].Name)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccInvalidSchemaReturnsError(t *testing.T) {
 	tempSchemas(t, mysqlURL, "test")
 	testAccValidSchema := fmt.Sprintf(`


### PR DESCRIPTION
- **atlas/schema: don't deps on URL for cleanup schema**
- **atlas/schema: support `atlas.hcl` and variables**
