### PR TITLE
atlas/migration: support custom env_name on datasource

### DIFF
--- a/docs/data-sources/migration.md
+++ b/docs/data-sources/migration.md
@@ -27,6 +27,7 @@ data "atlas_migration" "hello" {
 - `cloud` (Block, Optional) (see [below for nested schema](#nestedblock--cloud))
 - `config` (String) The configuration file for the migration
 - `dir` (String) Select migration directory using URL format
+- `env_name` (String) The name of the environment used for reporting runs to Atlas Cloud. Default: tf
 - `remote_dir` (Block, Optional, Deprecated) (see [below for nested schema](#nestedblock--remote_dir))
 - `revisions_schema` (String) The name of the schema the revisions table resides in
 - `url` (String, Sensitive) [driver://username:password@address/dbname?param=value] select a resource using the URL format

--- a/internal/provider/atlas_migration_data_source.go
+++ b/internal/provider/atlas_migration_data_source.go
@@ -30,6 +30,7 @@ type (
 		DirURL    types.String     `tfsdk:"dir"`
 		Cloud     *AtlasCloudBlock `tfsdk:"cloud"`
 		RemoteDir *RemoteDirBlock  `tfsdk:"remote_dir"`
+		EnvName   types.String     `tfsdk:"env_name"`
 
 		Status  types.String `tfsdk:"status"`
 		Current types.String `tfsdk:"current"`
@@ -106,6 +107,10 @@ func (d *MigrationDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			},
 			"dir": schema.StringAttribute{
 				Description: "Select migration directory using URL format",
+				Optional:    true,
+			},
+			"env_name": schema.StringAttribute{
+				Description: "The name of the environment used for reporting runs to Atlas Cloud. Default: tf",
 				Optional:    true,
 			},
 			"revisions_schema": schema.StringAttribute{
@@ -225,7 +230,7 @@ func (d *MigrationDataSourceModel) projectConfig(cloud *AtlasCloudBlock) (*proje
 	}
 	cfg := projectConfig{
 		Config:  defaultString(d.Config, baseAtlasHCL),
-		EnvName: "tf",
+		EnvName: defaultString(d.EnvName, "tf"),
 		Env: &envConfig{
 			URL: dbURL,
 			Migration: &migrationConfig{

--- a/internal/provider/atlas_migration_data_source_test.go
+++ b/internal/provider/atlas_migration_data_source_test.go
@@ -78,6 +78,7 @@ locals {
 	db_url = getenv("DB_URL")
 }
 env {
+	name = atlas.env
 	url = urlsetpath(local.db_url, var.schema_name)
 	migration {
 		dir = "this-dir-does-not-exist-and-always-gets-overrides"

--- a/internal/provider/atlas_migration_resource_test.go
+++ b/internal/provider/atlas_migration_resource_test.go
@@ -251,6 +251,7 @@ variable "schemas" {
 	type = list(string)
 }
 env {
+	name     = atlas.env
 	for_each = toset(var.schemas)
 	url      = urlsetpath(var.url, each.value)
 	migration {

--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -53,7 +53,7 @@ type (
 )
 
 // we will allow the user configure the base atlas.hcl file
-const baseAtlasHCL = "env {\n}"
+const baseAtlasHCL = "env {\n  name = atlas.env\n}"
 
 // Render writes the atlas config to the given writer.
 func (c *projectConfig) Render(w io.Writer) error {
@@ -83,10 +83,6 @@ func (c *projectConfig) File() *hclwrite.File {
 	}
 	if env := c.Env; env != nil {
 		e := r.AppendNewBlock("env", nil).Body()
-		e.SetAttributeTraversal("name", hcl.Traversal{
-			hcl.TraverseRoot{Name: "atlas"},
-			hcl.TraverseAttr{Name: "env"},
-		})
 		if env.URL != "" {
 			e.SetAttributeValue("url", cty.StringVal(env.URL))
 		}

--- a/internal/provider/builder_test.go
+++ b/internal/provider/builder_test.go
@@ -127,8 +127,8 @@ func Test_SchemaTemplate(t *testing.T) {
 	out := &bytes.Buffer{}
 	require.NoError(t, data.Render(out))
 	require.Equal(t, `env {
-  dev  = "mysql://user:pass@localhost:3307/tf-db"
   name = atlas.env
+  dev  = "mysql://user:pass@localhost:3307/tf-db"
   src  = "file://schema.hcl"
   url  = "mysql://user:pass@localhost:3306/tf-db"
   diff {


### PR DESCRIPTION
- **atlas/migration: support custom env_name on datasource**
- **builder: remove `atlas.env` from the generated config**
