### PR TITLE
provider: merge `env` block only with its name

### DIFF
--- a/internal/provider/atlas_migration_data_source_test.go
+++ b/internal/provider/atlas_migration_data_source_test.go
@@ -69,8 +69,9 @@ func TestAccMigrationDataSource(t *testing.T) {
 data "atlas_migration" "hello" {
 	# The dir attribute is required to be set, and
 	# can't be supplied from the atlas.hcl
-	dir    = "file://migrations?format=atlas"
-	config = <<-HCL
+	dir      = "file://migrations?format=atlas"
+	env_name = "tf"
+	config   = <<-HCL
 variable "schema_name" {
 	type = string
 }
@@ -122,12 +123,17 @@ func TestAccMigrationDataSource_AtlasURL(t *testing.T) {
 		}))
 		config = fmt.Sprintf(`
 data "atlas_migration" "hello" {
-	url = "%s"
-	dir = "atlas://test"
-	cloud {
-		token = "aci_bearer_token"
-		url   = "%s"
-	}
+	url      = "%s"
+	dir      = "atlas://test"
+	env_name = "tf"
+	config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%s"
+  }
+}
+HCL
 }`, dbURL, srv.URL)
 	)
 	t.Cleanup(srv.Close)
@@ -140,13 +146,18 @@ data "atlas_migration" "hello" {
 				{
 					Config: fmt.Sprintf(`
 data "atlas_migration" "hello" {
-	url = "%s"
+	url      = "%s"
+	env_name = "tf"
+	config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%s"
+  }
+}
+HCL
 	remote_dir {
 		name = "test"
-	}
-	cloud {
-		token = "aci_bearer_token"
-		url   = "%s"
 	}
 }`, dbURL, srv.URL),
 					Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/atlas_migration_resource_test.go
+++ b/internal/provider/atlas_migration_resource_test.go
@@ -272,6 +272,7 @@ HCL
 		# can't be supplied from the atlas.hcl
 		dir       = "file://migrations"
 		config    = local.config
+		env_name  = "tf"
 		variables = local.vars
 	}
 	resource "atlas_migration" "testdb" {
@@ -279,6 +280,7 @@ HCL
 		# can't be supplied from the atlas.hcl
 		dir       = "file://migrations"
 		version   = data.atlas_migration.hello.next
+		env_name  = "tf"
 		config    = local.config
 		variables = local.vars
 	}`, mysqlURL)
@@ -551,23 +553,23 @@ func TestAccMigrationResource_AtlasURL(t *testing.T) {
 		}))
 		config = fmt.Sprintf(`
 		data "atlas_migration" "hello" {
-			url = "%[2]s"
-			dir = "atlas://test"
-			cloud {
-				token   = "aci_bearer_token"
-				url     = "%[1]s"
-				project = "test"
-			}
+			url      = "%[2]s"
+			dir      = "atlas://test"
+			env_name = "tf"
+			config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[1]s"
+  }
+}
+HCL
 		}
 		resource "atlas_migration" "testdb" {
 			url     = "%[2]s"
 			version = data.atlas_migration.hello.next
 			dir     = data.atlas_migration.hello.dir
-			cloud {
-				token   = "aci_bearer_token"
-				url     = "%[1]s"
-				project = "test"
-			}
+			config  = data.atlas_migration.hello.config
 		}
 		`, srv.URL, dbURL)
 	)
@@ -684,13 +686,17 @@ func TestAccMigrationResource_AtlasURL_WithTag(t *testing.T) {
 		dev_url = "%[1]s"
 	}
 	resource "atlas_migration" "hello" {
-		url = "%[3]s"
-		dir = "atlas://test"
-		cloud {
-			token   = "aci_bearer_token"
-			url     = "%[2]s"
-			project = "test"
-		}
+		url      = "%[3]s"
+		dir      = "atlas://test"
+		env_name = "tf"
+		config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 	}
 	`, devURL, srv.URL, dbURL)
 	resource.Test(t, resource.TestCase{
@@ -715,17 +721,21 @@ func TestAccMigrationResource_AtlasURL_WithTag(t *testing.T) {
 		dev_url = "%[1]s"
 	}
 	resource "atlas_migration" "hello" {
-		url = "%[3]s"
-		dir = "atlas://test?tag=one-down"
+		url      = "%[3]s"
+		dir      = "atlas://test?tag=one-down"
+		env_name = "tf"
+		config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 		protected_flows {
 			migrate_down {
 				allow = true
 			}
-		}
-		cloud {
-			token   = "aci_bearer_token"
-			url     = "%[2]s"
-			project = "test"
 		}
 	}
 	`, devURL, srv.URL, dbURL)
@@ -751,13 +761,17 @@ func TestAccMigrationResource_AtlasURL_WithTag(t *testing.T) {
 		dev_url = "%[1]s"
 	}
 	resource "atlas_migration" "hello" {
-		url = "%[3]s"
-		dir = "atlas://test?tag=latest"
-		cloud {
-			token   = "aci_bearer_token"
-			url     = "%[2]s"
-			project = "test"
-		}
+		url      = "%[3]s"
+		dir      = "atlas://test?tag=latest"
+		env_name = "tf"
+		config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 	}`, devURL, srv.URL, dbURL)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -895,13 +909,17 @@ func TestAccMigrationResource_RequireApproval(t *testing.T) {
 					dev_url = "%[1]s"
 				}
 				resource "atlas_migration" "hello" {
-					url = "%[3]s"
-					dir = "atlas://test?tag=latest"
-					cloud {
-						token   = "aci_bearer_token"
-						url     = "%[2]s"
-						project = "test"
-					}
+					url      = "%[3]s"
+					dir      = "atlas://test?tag=latest"
+					env_name = "tf"
+					config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 				}`, devURL, srv.URL, dbURL),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("atlas_migration.hello", "id", "remote_dir://test"),
@@ -923,13 +941,17 @@ func TestAccMigrationResource_RequireApproval(t *testing.T) {
 					dev_url = "%[1]s"
 				}
 				resource "atlas_migration" "hello" {
-					url = "%[3]s"
-					dir = "atlas://test?tag=tag3"
-					cloud {
-						token   = "aci_bearer_token"
-						url     = "%[2]s"
-						project = "test"
-					}
+					url      = "%[3]s"
+					dir      = "atlas://test?tag=tag3"
+					env_name = "tf"
+					config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 				}`, devURL, srv.URL, dbURL),
 				ExpectError: regexp.MustCompile("migrate down is not allowed, set `migrate_down.allow` to true to allow"),
 			},
@@ -945,13 +967,17 @@ func TestAccMigrationResource_RequireApproval(t *testing.T) {
 					dev_url = "%[1]s"
 				}
 				resource "atlas_migration" "hello" {
-					url = "%[3]s"
-					dir = "atlas://test?tag=tag3"
-					cloud {
-						token   = "aci_bearer_token"
-						url     = "%[2]s"
-						project = "test"
-					}
+					url      = "%[3]s"
+					dir      = "atlas://test?tag=tag3"
+					env_name = "tf"
+					config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 					protected_flows {
 						migrate_down {
 							allow        = true
@@ -976,13 +1002,17 @@ func TestAccMigrationResource_RequireApproval(t *testing.T) {
 					dev_url = "%[1]s"
 				}
 				resource "atlas_migration" "hello" {
-					url = "%[3]s"
-					dir = "atlas://test?tag=tag3"
-					cloud {
-						token   = "aci_bearer_token"
-						url     = "%[2]s"
-						project = "test"
-					}
+					url      = "%[3]s"
+					dir      = "atlas://test?tag=tag3"
+					env_name = "tf"
+					config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 					protected_flows {
 						migrate_down {
 							allow = true
@@ -1010,13 +1040,17 @@ func TestAccMigrationResource_RequireApproval(t *testing.T) {
 					dev_url = "%[1]s"
 				}
 				resource "atlas_migration" "hello" {
-					url = "%[3]s"
-					dir = "atlas://test?tag=tag2"
-					cloud {
-						token   = "aci_bearer_token"
-						url     = "%[2]s"
-						project = "test"
-					}
+					url      = "%[3]s"
+					dir      = "atlas://test?tag=tag2"
+					env_name = "tf"
+					config   = <<-HCL
+atlas {
+  cloud {
+    token = "aci_bearer_token"
+    url   = "%[2]s"
+  }
+}
+HCL
 					protected_flows {
 						migrate_down {
 							allow = true

--- a/internal/provider/atlas_schema_data_source.go
+++ b/internal/provider/atlas_schema_data_source.go
@@ -134,7 +134,7 @@ func (d *AtlasSchemaDataSource) Read(ctx context.Context, req datasource.ReadReq
 			})
 		}
 	}()
-	c, err := d.client(wd.Path())
+	c, err := d.client(wd.Path(), cfg.Cloud)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create client, got error: %s", err),
@@ -158,7 +158,6 @@ func (d *AtlasSchemaDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 func (d *AtlasSchemaDataSourceModel) projectConfig(cloud *AtlasCloudBlock, devURL string) (*projectConfig, *atlas.WorkingDir, error) {
 	cfg := &projectConfig{
-		Config:  baseAtlasHCL,
 		EnvName: "tf",
 		Env: &envConfig{
 			URL:    "file://schema.hcl",
@@ -166,7 +165,7 @@ func (d *AtlasSchemaDataSourceModel) projectConfig(cloud *AtlasCloudBlock, devUR
 		},
 	}
 	if cloud.Valid() {
-		cfg.Cloud = &cloudConfig{
+		cfg.Cloud = &CloudConfig{
 			Token: cloud.Token.ValueString(),
 		}
 	}

--- a/internal/provider/atlas_schema_resource_test.go
+++ b/internal/provider/atlas_schema_resource_test.go
@@ -650,7 +650,7 @@ table "orders" {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDiags := provider.PrintPlanSQL(tt.args.ctx, nil, func(wd string) (provider.AtlasExec, error) {
+			gotDiags := provider.PrintPlanSQL(tt.args.ctx, nil, func(wd string, _ *provider.CloudConfig) (provider.AtlasExec, error) {
 				return atlas.NewClient(wd, "atlas")
 			}, mysqlDevURL, tt.args.data)
 			require.Equal(t, tt.wantDiags, gotDiags)

--- a/internal/provider/testdata/TestTemplate/baseline-cfg.hcl
+++ b/internal/provider/testdata/TestTemplate/baseline-cfg.hcl
@@ -1,6 +1,5 @@
-env {
-  name = atlas.env
-  url  = "mysql://user:pass@localhost:3306/tf-db"
+env "tf" {
+  url = "mysql://user:pass@localhost:3306/tf-db"
   migration {
     dir      = "file://migrations"
     baseline = "100000"

--- a/internal/provider/testdata/TestTemplate/cloud-cfg.hcl
+++ b/internal/provider/testdata/TestTemplate/cloud-cfg.hcl
@@ -1,14 +1,6 @@
-env {
-  name = atlas.env
-  url  = "mysql://user:pass@localhost:3306/tf-db"
+env "tf" {
+  url = "mysql://user:pass@localhost:3306/tf-db"
   migration {
     dir = "atlas://tf-dir?tag=latest"
-  }
-}
-atlas {
-  cloud {
-    token   = "token"
-    project = "project"
-    url     = "url"
   }
 }

--- a/internal/provider/testdata/TestTemplate/cloud-tag-cfg.hcl
+++ b/internal/provider/testdata/TestTemplate/cloud-tag-cfg.hcl
@@ -1,12 +1,6 @@
-env {
-  name = atlas.env
-  url  = "mysql://user:pass@localhost:3306/tf-db"
+env "tf" {
+  url = "mysql://user:pass@localhost:3306/tf-db"
   migration {
     dir = "atlas://tf-dir?tag=tag"
-  }
-}
-atlas {
-  cloud {
-    token = "token"
   }
 }

--- a/internal/provider/testdata/TestTemplate/local-cfg.hcl
+++ b/internal/provider/testdata/TestTemplate/local-cfg.hcl
@@ -1,6 +1,5 @@
-env {
-  name = atlas.env
-  url  = "mysql://user:pass@localhost:3306/tf-db"
+env "tf" {
+  url = "mysql://user:pass@localhost:3306/tf-db"
   migration {
     dir = "file://migrations"
   }

--- a/internal/provider/testdata/TestTemplate/local-exec-order-cfg.hcl
+++ b/internal/provider/testdata/TestTemplate/local-exec-order-cfg.hcl
@@ -1,6 +1,5 @@
-env {
-  name = atlas.env
-  url  = "mysql://user:pass@localhost:3306/tf-db"
+env "tf" {
+  url = "mysql://user:pass@localhost:3306/tf-db"
   migration {
     dir        = "file://migrations"
     exec_order = LINEAR_SKIP

--- a/internal/provider/testdata/TestTemplate/token-cfg.hcl
+++ b/internal/provider/testdata/TestTemplate/token-cfg.hcl
@@ -1,12 +1,6 @@
-env {
-  name = atlas.env
-  url  = "mysql://user:pass@localhost:3306/tf-db"
+env "tf" {
+  url = "mysql://user:pass@localhost:3306/tf-db"
   migration {
     dir = "file://migrations"
-  }
-}
-atlas {
-  cloud {
-    token = "token+%=_-"
   }
 }


### PR DESCRIPTION
- If the `config` attribute is provided, the `env_name` also required.
- We only merge the env block that generated by the resource with the matched env block.
- The `atlas { cloud { ... } }` block no longer generated, we supply the `cloud.token` via `ATLAS_TOKEN` env.
- `cloud.url` and `cloud.project` has no effect, and will be remove