### PR TITLE
provider: add lint policy support for schema changes

### DIFF
--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -37,6 +37,7 @@ resource "atlas_schema" "market" {
 - `dev_url` (String, Sensitive) The url of the dev-db see https://atlasgo.io/cli/url
 - `diff` (Block, Optional) (see [below for nested schema](#nestedblock--diff))
 - `exclude` (List of String) Filter out resources matching the given glob pattern. See https://atlasgo.io/declarative/inspect#exclude-schemas
+- `lint` (Block, Optional) The lint policy (see [below for nested schema](#nestedblock--lint))
 - `tx_mode` (String) The transaction mode to use when applying the schema. See https://atlasgo.io/versioned/apply#transaction-configuration
 
 ### Read-Only
@@ -80,3 +81,12 @@ Optional:
 - `modify_index` (Boolean) Whether to skip modifying indexes
 - `modify_schema` (Boolean) Whether to skip modifying schemas
 - `modify_table` (Boolean) Whether to skip modifying tables
+
+
+
+<a id="nestedblock--lint"></a>
+### Nested Schema for `lint`
+
+Optional:
+
+- `review` (String) The review policy

--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -41,6 +41,7 @@ type (
 		Schemas   []string
 		Exclude   []string
 		Diff      *Diff
+		Lint      *Lint
 		Migration *migrationConfig
 	}
 	CloudConfig struct {
@@ -130,6 +131,12 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 			attrBoolPtr(b, v.AddForeignKey, "add_foreign_key")
 			attrBoolPtr(b, v.DropForeignKey, "drop_foreign_key")
 			attrBoolPtr(b, v.ModifyForeignKey, "modify_foreign_key")
+		}
+	}
+	if ld := env.Lint; ld != nil {
+		l := e.AppendNewBlock("lint", nil).Body()
+		if r := ld.Review; !r.IsNull() {
+			l.SetAttributeValue("review", cty.StringVal(r.ValueString()))
 		}
 	}
 	return blk


### PR DESCRIPTION
This pull request introduces the `lint` policy to the schema resource. These changes won't affect the existing logic since `auto-approve` is always set. This prepares for the feature approval flow in an upcoming PR

### Linting Feature Addition:

* [`internal/provider/atlas_schema_resource.go`](diffhunk://#diff-20b1443a1f8eae7ad11c90cc142e91601375b875c30a2d05bbfed02dc9d7ed40R40-R50): Added a new `Lint` struct to define lint policies and updated the schema to include a `lint` block. [[1]](diffhunk://#diff-20b1443a1f8eae7ad11c90cc142e91601375b875c30a2d05bbfed02dc9d7ed40R40-R50) [[2]](diffhunk://#diff-20b1443a1f8eae7ad11c90cc142e91601375b875c30a2d05bbfed02dc9d7ed40R115-R126) [[3]](diffhunk://#diff-20b1443a1f8eae7ad11c90cc142e91601375b875c30a2d05bbfed02dc9d7ed40R155) [[4]](diffhunk://#diff-20b1443a1f8eae7ad11c90cc142e91601375b875c30a2d05bbfed02dc9d7ed40R524)
* [`internal/provider/builder.go`](diffhunk://#diff-ae374c02f0c2234da8c0434fc9fc61bcc5dcd50d4178d1afacf1cc7ce8abba26R44): Updated the `envConfig` struct to include a `Lint` field and modified the `AsBlock` method to handle the new lint policies. [[1]](diffhunk://#diff-ae374c02f0c2234da8c0434fc9fc61bcc5dcd50d4178d1afacf1cc7ce8abba26R44) [[2]](diffhunk://#diff-ae374c02f0c2234da8c0434fc9fc61bcc5dcd50d4178d1afacf1cc7ce8abba26R136-R141)

### Test Updates:

* [`internal/provider/builder_test.go`](diffhunk://#diff-1316fc900750bd5596165751087750b569e2b20dd6a99ad3d7431532bae8831dL101-R119): Added new test cases in the `Test_SchemaTemplate` function to validate the linting feature. [[1]](diffhunk://#diff-1316fc900750bd5596165751087750b569e2b20dd6a99ad3d7431532bae8831dL101-R119) [[2]](diffhunk://#diff-1316fc900750bd5596165751087750b569e2b20dd6a99ad3d7431532bae8831dR135-R140) [[3]](diffhunk://#diff-1316fc900750bd5596165751087750b569e2b20dd6a99ad3d7431532bae8831dR153-L136)