### PR TITLE
internal/provider: applying schema resource with lint policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
           terraform_wrapper: false
       - name: Install Atlas CLI
         uses: ariga/setup-atlas@v0
+        with:
+          cloud-token: ${{ secrets.ATLAS_TOKEN }}
         env:
           ATLAS_DEBUG: "true"
       - run: go test -v -cover ./...

--- a/internal/provider/atlas_schema_resource.go
+++ b/internal/provider/atlas_schema_resource.go
@@ -477,7 +477,7 @@ func (r *AtlasSchemaResource) applySchema(ctx context.Context, data *AtlasSchema
 		Env:         cfg.EnvName,
 		Vars:        cfg.Vars,
 		TxMode:      data.TxMode.ValueString(),
-		AutoApprove: true,
+		AutoApprove: !data.ShouldReview(),
 	})
 	if err != nil {
 		diags.AddError("Apply Error",
@@ -513,7 +513,7 @@ func (r *AtlasSchemaResource) firstRunCheck(ctx context.Context, data *AtlasSche
 		DryRun:      true,
 		Env:         cfg.EnvName,
 		Vars:        cfg.Vars,
-		AutoApprove: true,
+		AutoApprove: !data.ShouldReview(),
 	})
 	if err != nil {
 		diags.AddError("Atlas Plan Error",
@@ -580,6 +580,11 @@ func (d *AtlasSchemaResourceModel) Workspace(ctx context.Context, p *ProviderDat
 		return nil, nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 	return cfg, wd, nil
+}
+
+// ShouldReview returns true if the `review` attribute in the lint block is set.
+func (d *AtlasSchemaResourceModel) ShouldReview() bool {
+	return d.Lint != nil && d.Lint.Review.ValueString() != ""
 }
 
 func boolOptional(desc string) schema.Attribute {


### PR DESCRIPTION
The `auto_approve` flag is set to `true` by default, which bypasses the `lint` policy even if it is specified. This PR will toggle the flag based on the presence of the `lint` policy.