### PR TITLE
internal/provider: allow using custom project config for schema resource

### DIFF
--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -30,15 +30,18 @@ resource "atlas_schema" "market" {
 ### Required
 
 - `hcl` (String) The schema definition for the database (preferably normalized - see `atlas_schema` data source)
-- `url` (String, Sensitive) The url of the database see https://atlasgo.io/cli/url
 
 ### Optional
 
+- `config` (String) The content of atlas.hcl config
 - `dev_url` (String, Sensitive) The url of the dev-db see https://atlasgo.io/cli/url
 - `diff` (Block, Optional) (see [below for nested schema](#nestedblock--diff))
+- `env_name` (String) The name of the environment used for reporting runs to Atlas Cloud. Default: tf
 - `exclude` (List of String) Filter out resources matching the given glob pattern. See https://atlasgo.io/declarative/inspect#exclude-schemas
 - `lint` (Block, Optional) The lint policy (see [below for nested schema](#nestedblock--lint))
 - `tx_mode` (String) The transaction mode to use when applying the schema. See https://atlasgo.io/versioned/apply#transaction-configuration
+- `url` (String, Sensitive) The url of the database see https://atlasgo.io/cli/url
+- `variables` (String) Stringify JSON object containing variables to be used inside the Atlas configuration file.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/mitchellh/cli v1.1.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peK
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	_ "ariga.io/atlas/sql/mysql"
+	_ "ariga.io/atlas/sql/sqlite"
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"


### PR DESCRIPTION
This pull request supports injecting `atlas.hcl` into the schema resource. There are three new attributes, which are the same as those in the migrate resource: `config`, `env_name`, and `variables`.

Example usage:
```tf
locals {
	config = <<-HCL
              variable "db_url" {
	              type = string
              }
              variable "dev_db_url" {
	              type = string
              }
              env "test" {
	              url = var.db_url
	              dev = var.dev_db_url
              }
	HCL
	vars = jsonencode({
		db_url: "database url",
		dev_db_url: "dev database url",
	})
}

resource "atlas_schema" "example" {
        env_name = "test"
	config = local.config
	variables = local.vars
	hcl = <<-EOT
            schema "main" {}
            table "t1" {
	            schema = schema.main
	            column "c1" {
		            null = false
		            type = int
	            }
            }
	EOT
}
```