### PR TITLE
internal/provider: use uuid as id and remove redundant tests

### DIFF
--- a/internal/provider/atlas_migration_resource_test.go
+++ b/internal/provider/atlas_migration_resource_test.go
@@ -601,7 +601,6 @@ HCL
 					Config:             config,
 					ExpectNonEmptyPlan: true,
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("atlas_migration.testdb", "id", "remote_dir://test"),
 						resource.TestCheckResourceAttr("atlas_migration.testdb", "status.current", "1"),
 						resource.TestCheckResourceAttr("atlas_migration.testdb", "status.latest", "2"),
 						resource.TestCheckResourceAttr("atlas_migration.testdb", "status.next", "2"),
@@ -611,7 +610,6 @@ HCL
 					Config:             config,
 					ExpectNonEmptyPlan: true,
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("atlas_migration.testdb", "id", "remote_dir://test"),
 						resource.TestCheckResourceAttr("atlas_migration.testdb", "status.current", "2"),
 						resource.TestCheckResourceAttr("atlas_migration.testdb", "status.latest", "2"),
 						resource.TestCheckNoResourceAttr("atlas_migration.testdb", "status.next"),
@@ -707,7 +705,6 @@ HCL
 			{
 				Config: config,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlas_migration.hello", "id", "remote_dir://test"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "dir", "atlas://test"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.current", "2"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.latest", "2"),
@@ -747,7 +744,6 @@ HCL
 			{
 				Config: config,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlas_migration.hello", "id", "remote_dir://test"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "dir", "atlas://test?tag=one-down"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.current", "1"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.latest", "1"),
@@ -781,7 +777,6 @@ HCL
 			{
 				Config: config,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlas_migration.hello", "id", "remote_dir://test"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "dir", "atlas://test?tag=latest"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.current", "2"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.latest", "2"),
@@ -923,7 +918,6 @@ atlas {
 HCL
 				}`, devURL, srv.URL, dbURL),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlas_migration.hello", "id", "remote_dir://test"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.current", "4"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.latest", "4"),
 					resource.TestCheckNoResourceAttr("atlas_migration.hello", "status.next"),
@@ -1021,7 +1015,6 @@ HCL
 					}
 				}`, devURL, srv.URL, dbURL),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlas_migration.hello", "id", "remote_dir://test"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.current", "3"),
 					resource.TestCheckResourceAttr("atlas_migration.hello", "status.latest", "3"),
 					resource.TestCheckNoResourceAttr("atlas_migration.hello", "status.next"),


### PR DESCRIPTION
Before these changes, the `schema` resource ID was derived from the `url` attribute, which was mandatory. With the introduction of `atlas.hcl` support, the `url` attribute is now optional, as the URL can be specified within `atlas.hcl`. To eliminate unnecessary dependencies, the resource ID generation logic has been updated to use a UUID instead.

### Potential Side Effects
None. Terraform relies on the id attribute for managing remote resources, while the Atlas schema is only referenced by local resources. Therefore, this modification does not impact Terraform's resource tracking or state management.