### PR TITLE
internal/provider: enhance schema apply with approval flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,19 @@ jobs:
           ! cat stdout.txt | grep --silent "Warning: version is unset"
         env:
           TF_VAR_atlas_token: ${{ secrets.ATLAS_TOKEN }}
+      - name: Terraform (review)
+        working-directory: integration-tests/review
+        run: |
+          ../../scripts/local.sh ../../dist 0.0.0-pre.0
+          terraform init > /dev/null
+          echo "Apply terraform plan"
+          terraform apply -no-color --auto-approve > stdout.txt
+          cat stdout.txt | grep --silent "Apply complete! Resources: 1 added, 0 changed, 0 destroyed."
+          echo "Ensure that there is no diff"
+          terraform plan -no-color > stdout.txt
+          cat stdout.txt | grep --silent "No changes. Your infrastructure matches the configuration."
+        env:
+          TF_VAR_atlas_token: ${{ secrets.ATLAS_TOKEN }}
   integration-mysql:
     name: Integration MySQL (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -105,3 +105,4 @@ Optional:
 Optional:
 
 - `review` (String) The review policy
+- `review_timeout` (String) The review timeout

--- a/integration-tests/review/main.tf
+++ b/integration-tests/review/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    atlas = {
+      source  = "ariga/atlas"
+      version = "0.0.0-pre.0"
+    }
+  }
+}
+
+variable "atlas_token" {
+  type      = string
+  sensitive = true
+}
+
+provider "atlas" {
+  cloud {
+    token = var.atlas_token
+  }
+}
+
+resource "atlas_schema" "db" {
+  hcl = <<-EOT
+    table "t1" {
+      schema = schema.main
+      column "c1" {
+        null = false
+        type = int
+      }
+    }
+    schema "main" {
+    }
+  EOT
+  lint {
+    review = "ALWAYS"
+  }
+  cloud {
+    repo = "atlas-terraform"
+  }
+  url = "sqlite://example.db"
+  dev_url = "sqlite://test.db?mode=memory"
+}

--- a/internal/provider/atlas_schema_resource.go
+++ b/internal/provider/atlas_schema_resource.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -54,6 +56,8 @@ type (
 	// Lint defines the lint policies to apply when planning schema changes.
 	Lint struct {
 		Review types.String `tfsdk:"review"`
+		// ReviewTimeout defines the wait time for the review to be approved.
+		ReviewTimeout types.String `tfsdk:"review_timeout"`
 	}
 	ConcurrentIndex struct {
 		Create types.Bool `tfsdk:"create"`
@@ -127,6 +131,13 @@ var (
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("ALWAYS", "WARNING", "ERROR"),
+				},
+			},
+			"review_timeout": schema.StringAttribute{
+				Description: "The review timeout",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[smhd]$`), "Must be a valid duration (e.g. 1m, 2h)"),
 				},
 			},
 		},
@@ -305,6 +316,25 @@ func (r AtlasSchemaResource) ValidateConfig(ctx context.Context, req resource.Va
 }
 
 // ModifyPlan implements resource.ResourceWithModifyPlan.
+// ModifyPlan is a method of AtlasSchemaResource that modifies the Terraform resource plan
+// before it is applied. It performs various checks and adjustments to ensure the plan is
+// valid and safe to execute.
+//
+// Parameters:
+// - ctx: The context for the operation, used for cancellation and deadlines.
+// - req: The ModifyPlanRequest containing the current state and desired plan of the resource.
+// - resp: The ModifyPlanResponse used to append diagnostics and indicate required changes.
+//
+// Behavior:
+//   - Retrieves the desired plan and current state of the resource.
+//   - If the current state is nil or the HCL field is empty, it checks if the plan requires
+//     replacement or performs a first-run check to prevent accidental schema drops.
+//   - Handles delete operations by cloning the state into the plan and marking it as a delete operation.
+//   - Calls PrintPlanSQL to generate and log the SQL representation of the plan, appending any diagnostics.
+//   - If warnings are detected in the diagnostics, it triggers a schema review process.
+//
+// This method ensures that the resource plan is consistent, safe, and adheres to the expected
+// behavior of the Terraform provider.
 func (r *AtlasSchemaResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	var plan *AtlasSchemaResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -341,6 +371,7 @@ func (r *AtlasSchemaResource) ModifyPlan(ctx context.Context, req resource.Modif
 		isDelete = true
 	}
 	resp.Diagnostics.Append(PrintPlanSQL(ctx, &r.ProviderData, plan, isDelete)...)
+	resp.Diagnostics.Append(r.reviewSchema(ctx, plan)...)
 }
 
 func PrintPlanSQL(ctx context.Context, p *ProviderData, data *AtlasSchemaResourceModel, delete bool) (diags diag.Diagnostics) {
@@ -438,25 +469,135 @@ func (r *AtlasSchemaResource) applySchema(ctx context.Context, data *AtlasSchema
 		)
 		return
 	}
-	// If the repository URL is not set, apply the schema changes directly.
-	if repoURL == nil {
-		if _, err = w.Exec.SchemaApply(ctx, &atlas.SchemaApplyParams{
-			Env:         w.Project.EnvName,
-			Vars:        w.Project.Vars,
-			TxMode:      data.TxMode.ValueString(),
-			AutoApprove: review == nil,
-		}); err != nil {
-			diags.AddError("Apply Error",
-				fmt.Sprintf("Unable to apply changes, got error: %s", err),
+	var planURL string
+	// The approval flow is only enabled when repoURL is configured to connect to Atlas Cloud.
+	// If repoURL is not set, the flow is disabled, and changes are applied directly.
+	if review != nil && repoURL != nil {
+		targetURL, err := w.Project.TargetURL()
+		if err != nil {
+			diags.AddError("Failed to retrieve target URL",
+				fmt.Sprintf("Error getting target URL: %s", err),
 			)
 			return
 		}
+		timeout := time.Duration(0)
+		if data.Lint != nil && data.Lint.ReviewTimeout.ValueString() != "" {
+			timeoutStr := data.Lint.ReviewTimeout.ValueString()
+			timeout, err = time.ParseDuration(timeoutStr)
+			if err != nil {
+				diags.AddError("Invalid review timeout format",
+					fmt.Sprintf("Invalid review timeout format '%s': %s", timeoutStr, err),
+				)
+				return
+			}
+		}
+		now := time.Now()
+		for {
+			// Check context cancellation
+			if ctx.Err() != nil {
+				diags.AddError("Waiting for plan approval",
+					fmt.Sprintf("Context was cancelled: %s", ctx.Err()),
+				)
+				return
+			}
+			plans, err := w.Exec.SchemaPlanList(ctx, &atlas.SchemaPlanListParams{
+				Env:  w.Project.EnvName,
+				Vars: w.Project.Vars,
+				Repo: repoURL.String(),
+				From: []string{"env://url"},
+				To:   []string{targetURL},
+			})
+			if err != nil {
+				diags.AddError("Failed to list schema plans",
+					fmt.Sprintf("Couldn't retrieve schema plans: %s", err),
+				)
+				return
+			} else if len(plans) != 1 {
+				break
+			} else if len(plans) == 1 && plans[0].Status == "APPROVED" {
+				planURL = plans[0].URL
+				break
+			} else if len(plans) == 1 && plans[0].Status == "PENDING" {
+				if timeout == 0 {
+					diags.AddError("Plan Pending Approval",
+						fmt.Sprintf("The schema plan is awaiting approval. Please review and approve it before proceeding:\n\n%s", plans[0].Link),
+					)
+					return
+				}
+				if time.Since(now) > timeout {
+					diags.AddError("Plan Approval Timeout",
+						fmt.Sprintf("The schema plan is pending approval for too long. Please approve it before proceeding:\n\n%s", plans[0].Link),
+					)
+					return
+				}
+			}
+			// Sleep for a second before checking again
+			time.Sleep(1 * time.Second)
+		}
+	}
+	if _, err = w.Exec.SchemaApply(ctx, &atlas.SchemaApplyParams{
+		Env:         w.Project.EnvName,
+		Vars:        w.Project.Vars,
+		TxMode:      data.TxMode.ValueString(),
+		AutoApprove: review == nil,
+		PlanURL:     planURL,
+	}); err != nil {
+		diags.AddError("Apply Error",
+			fmt.Sprintf("Unable to apply changes, got error: %s", err),
+		)
+		return
+	}
+	return
+}
+
+func (r *AtlasSchemaResource) reviewSchema(ctx context.Context, data *AtlasSchemaResourceModel) (diags diag.Diagnostics) {
+	w, cleanup, err := data.Workspace(ctx, &r.ProviderData)
+	if err != nil {
+		diags.AddError("Generate config failure",
+			fmt.Sprintf("Failed to create workspace: %s", err.Error()))
+		return
+	}
+	defer cleanup()
+	review, err := w.Project.LintReview()
+	if err != nil {
+		diags.AddError("Configuration Error",
+			fmt.Sprintf("Unable to parse configuration, got error: %s", err),
+		)
+		return
+	}
+	repoURL, err := w.Project.RepoURL()
+	if err != nil {
+		diags.AddError("Failed to retrieve repo URL",
+			fmt.Sprintf("Error getting repo URL: %s", err),
+		)
+		return
+	}
+	if review == nil || repoURL == nil {
 		return
 	}
 	targetURL, err := w.Project.TargetURL()
 	if err != nil {
 		diags.AddError("Failed to retrieve target URL",
 			fmt.Sprintf("Error getting target URL: %s", err),
+		)
+		return
+	}
+	// Only run the review flow if there have a detected change
+	result, err := w.Exec.SchemaApply(ctx, &atlas.SchemaApplyParams{
+		Env:    w.Project.EnvName,
+		Vars:   w.Project.Vars,
+		TxMode: data.TxMode.ValueString(),
+		DryRun: true,
+	})
+	if err != nil {
+		diags.AddError("Atlas Plan Error",
+			fmt.Sprintf("Unable to generate migration plan, got error: %s", err),
+		)
+		return
+	}
+	if result.Applied == nil || (result.Applied != nil && len(result.Applied.Applied) == 0) {
+		diags.AddWarning("No changes detected",
+			"The schema has no changes to apply.",
 		)
 		return
 	}
@@ -534,25 +675,11 @@ func (r *AtlasSchemaResource) applySchema(ctx context.Context, data *AtlasSchema
 				strings.Join(planURLs, "\n- ")),
 		)
 	}
-	if plan != nil {
-		if plan.Status == "PENDING" {
-			diags.AddError("Plan Pending Approval",
-				fmt.Sprintf("The schema plan is awaiting approval. Please review and approve it before proceeding:\n\n%s", plan.Link),
-			)
-			return
-		}
-		_, err = w.Exec.SchemaApply(ctx, &atlas.SchemaApplyParams{
-			Env:     w.Project.EnvName,
-			Vars:    w.Project.Vars,
-			TxMode:  data.TxMode.ValueString(),
-			PlanURL: plan.URL,
-		})
-		if err != nil {
-			diags.AddError("Failed to apply schema changes",
-				fmt.Sprintf("Encountered an error applying schema changes: %s", err),
-			)
-			return
-		}
+	if plan != nil && plan.Status == "PENDING" {
+		diags.AddWarning("Plan Pending Approval",
+			fmt.Sprintf("The schema plan is awaiting approval. Please review and approve it before proceeding:\n\n%s", plan.Link),
+		)
+		return
 	}
 	return
 }

--- a/internal/provider/atlas_schema_resource_test.go
+++ b/internal/provider/atlas_schema_resource_test.go
@@ -2,11 +2,15 @@ package provider_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"ariga.io/atlas/sql/sqlclient"
@@ -722,10 +726,6 @@ resource "atlas_schema" "example" {
 				// ignore non-normalized schema
 				ExpectNonEmptyPlan: true,
 				Check: func(s *terraform.State) error {
-					cli, err := sqlclient.Open(context.Background(), url)
-					if err != nil {
-						return err
-					}
 					realm, err := cli.InspectRealm(context.Background(), nil)
 					if err != nil {
 						return err
@@ -913,6 +913,146 @@ resource "atlas_schema" "example" {
 	})
 }
 
+func TestApprovalFlow(t *testing.T) {
+	url := tmpDB(t)
+	cloud := tmpCloud(t)
+	cloud.AddSchema("test", `schema "test" {}`)
+	server := cloud.Start(t, "test token")
+	defer server.Close()
+	config := func(hcl string, review string) string {
+		return fmt.Sprintf(`
+			resource "atlas_schema" "example" {
+				hcl = <<-EOT
+					%s
+				EOT
+				cloud {
+					repo = "test"
+				}
+				config = <<-HCL
+					atlas {
+						cloud {
+							token = "test token"
+							url = %q
+						}
+					}
+					env {
+						name = atlas.env
+						lint {
+							review = %q
+							destructive {
+								error = true
+							}
+						}
+					}
+				HCL
+				url = %q
+				dev_url = %q
+			}`, hcl, server.URL, review, url, "sqlite://file.db?mode=memory")
+	}
+	cli, err := sqlclient.Open(context.Background(), url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// First run should create the plan in the cloud.
+			{
+				Config: config(`
+			schema "main" {}
+			table "t1" {
+				schema = schema.main
+				column "c1" {
+					type = int
+				}
+			}`, "ALWAYS"),
+				Destroy: false,
+				// ignore non-normalized schema
+				ExpectNonEmptyPlan: true,
+				Check: func(s *terraform.State) error {
+					// Expect the plan to be created in the cloud.
+					if len(cloud.plans) != 1 {
+						return fmt.Errorf("expected plan to be created in the cloud, but got none")
+					}
+					return nil
+				},
+				ExpectError: regexp.MustCompile("Plan Pending Approval"),
+			},
+			// Second run with approved plan should apply the changes.
+			{
+				PreConfig: func() {
+					cloud.ApproveAllPlan()
+				},
+				Config: config(`
+			schema "main" {}
+			table "t1" {
+				schema = schema.main
+				column "c1" {
+					type = int
+				}
+			}`, "ALWAYS"),
+				Destroy: false,
+				// ignore non-normalized schema
+				ExpectNonEmptyPlan: true,
+				Check: func(s *terraform.State) error {
+					realm, err := cli.InspectRealm(context.Background(), nil)
+					if err != nil {
+						return err
+					}
+					schema, ok := realm.Schema("main")
+					if !ok {
+						return fmt.Errorf("schema 'main' does not exist.")
+					}
+					if _, ok := schema.Table("t1"); !ok {
+						return fmt.Errorf("table 't1' does not exist.")
+					}
+					return nil
+				},
+			},
+			{
+				Config:  config(`schema "main" {}`, "ERROR"),
+				Destroy: false,
+				// ignore non-normalized schema
+				ExpectNonEmptyPlan: true,
+				Check: func(s *terraform.State) error {
+					// Expect the plan to be created in the cloud.
+					if len(cloud.plans) != 2 {
+						return fmt.Errorf("expected plan to be created in the cloud, but got none")
+					}
+					return nil
+				},
+				ExpectError: regexp.MustCompile("Plan Pending Approval"),
+			},
+			{
+				PreConfig: func() {
+					cloud.ApproveAllPlan()
+				},
+				Config:  config(`schema "main" {}`, "ERROR"),
+				Destroy: false,
+				// ignore non-normalized schema
+				ExpectNonEmptyPlan: true,
+				Check: func(s *terraform.State) error {
+					realm, err := cli.InspectRealm(context.Background(), nil)
+					if err != nil {
+						return err
+					}
+					schema, ok := realm.Schema("main")
+					if !ok {
+						return fmt.Errorf("schema 'main' does not exist.")
+					}
+					if _, ok := schema.Table("t1"); ok {
+						return fmt.Errorf("table 't1' should not exist.")
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
 // New temporary sqlite database for testing.
 // Returns uri to the database.
 func tmpDB(t *testing.T) string {
@@ -926,6 +1066,11 @@ func tmpDB(t *testing.T) string {
 		}
 	})
 	return "sqlite://" + filepath.Join(td, "test.db")
+}
+
+// New temporary Atlas cloud server for testing.
+func tmpCloud(t *testing.T) mockAtlasCloud {
+	return *NewMockAtlasCloud()
 }
 
 func tempSchemas(t *testing.T, url string, schemas ...string) *sqlclient.Client {
@@ -968,4 +1113,196 @@ func drop(t *testing.T, c *sqlclient.Client, schemas ...string) {
 			t.Errorf("failed closing client: %s", err)
 		}
 	})
+}
+
+type (
+	mockAtlasCloud struct {
+		schemas        map[string]Schema
+		plans          map[string]Plan
+		planFromHashes map[string][]Plan
+		planCount      int
+		schemaCount    int
+
+		mu sync.Mutex
+	}
+	Schema struct {
+		ID  int
+		HCL string
+	}
+	Plan struct {
+		ID         int    `json:"id"`
+		Name       string `json:"name"`
+		SchemaSlug string `json:"schemaSlug"`
+		Status     string `json:"status"`
+		FromHash   string `json:"fromHash"`
+		ToHash     string `json:"toHash"`
+		Link       string `json:"link"`
+		URL        string `json:"url"`
+		Migration  string `json:"migration"`
+	}
+)
+
+func NewMockAtlasCloud() *mockAtlasCloud {
+	return &mockAtlasCloud{
+		schemas:        make(map[string]Schema),
+		plans:          make(map[string]Plan),
+		planFromHashes: make(map[string][]Plan),
+	}
+}
+
+func (m *mockAtlasCloud) AddSchema(name, schema string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.schemaCount++
+	m.schemas[name] = Schema{
+		ID:  m.schemaCount,
+		HCL: schema,
+	}
+}
+
+func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash string, migration string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.planCount++
+	link := fmt.Sprintf("https://a8m.atlasgo.cloud/schemas/%d/plans/%d", m.schemaCount, m.planCount)
+	url := fmt.Sprintf("atlas://repo/schema/%s/plans/%s", schemaSlug, name)
+	plan := Plan{
+		ID:         m.planCount,
+		Name:       name,
+		SchemaSlug: schemaSlug,
+		Status:     status,
+		FromHash:   fromHash,
+		ToHash:     toHash,
+		Migration:  migration,
+		Link:       link,
+		URL:        url,
+	}
+	m.plans[name] = plan
+	hash := fmt.Sprintf("%s-%s", fromHash, toHash)
+	m.planFromHashes[hash] = append(m.planFromHashes[hash], plan)
+}
+
+func (m *mockAtlasCloud) ApproveAllPlan() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, plan := range m.plans {
+		plan.Status = "APPROVED"
+		m.plans[name] = plan
+	}
+	for hash, plans := range m.planFromHashes {
+		for i, p := range plans {
+			p.Status = "APPROVED"
+			m.planFromHashes[hash][i] = p
+		}
+	}
+}
+
+func (m *mockAtlasCloud) Start(t *testing.T, token string) *httptest.Server {
+	type (
+		SchemaStateInput struct {
+			Slug string `json:"slug"`
+		}
+		DeclarativePlanByHashesInput struct {
+			SchemaSlug string `json:"schemaSlug"`
+			FromHash   string `json:"fromHash"`
+			ToHash     string `json:"toHash"`
+		}
+		DeclarativePlanByNameInput struct {
+			SchemaSlug string `json:"schemaSlug"`
+			Name       string `json:"name"`
+		}
+		CreateDeclarativePlanInput struct {
+			Name       string `json:"name"`
+			SchemaSlug string `json:"schemaSlug"`
+			Status     string `json:"status"`
+			FromHash   string `json:"fromHash"`
+			ToHash     string `json:"toHash"`
+			Migration  string `json:"migration"`
+		}
+		graphQLQuery struct {
+			Query                string          `json:"query"`
+			Variables            json.RawMessage `json:"variables"`
+			SchemaStateVariables struct {
+				SchemaStateInput SchemaStateInput `json:"input"`
+			}
+			DeclarativePlanByHashesVariables struct {
+				DeclarativePlanByHashesInput DeclarativePlanByHashesInput `json:"input"`
+			}
+			DeclarativePlanByNameVariables struct {
+				DeclarativePlanByNameInput DeclarativePlanByNameInput `json:"input"`
+			}
+			CreateDeclarativePlanVariables struct {
+				CreateDeclarativePlanInput CreateDeclarativePlanInput `json:"input"`
+			}
+		}
+	)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		require.Equal(t, "Bearer "+token, r.Header.Get("Authorization"))
+		var query graphQLQuery
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&query))
+		switch {
+		case strings.Contains(query.Query, "schemaState"):
+			require.NoError(t, json.Unmarshal(query.Variables, &query.SchemaStateVariables))
+			schema, ok := m.schemas[query.SchemaStateVariables.SchemaStateInput.Slug]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			fmt.Fprintf(w, `{"data":{"schemaState": {"hcl": %q }}}`, schema.HCL)
+		case strings.Contains(query.Query, "CreateDeclarativePlan"):
+			require.NoError(t, json.Unmarshal(query.Variables, &query.CreateDeclarativePlanVariables))
+			input := query.CreateDeclarativePlanVariables.CreateDeclarativePlanInput
+			schema, ok := m.schemas[input.SchemaSlug]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			m.planCount++
+			link := fmt.Sprintf("https://a8m.atlasgo.cloud/schemas/%d/plans/%d", schema.ID, m.planCount)
+			url := fmt.Sprintf("atlas://%s/plans/%s", input.SchemaSlug, input.Name)
+			plan := Plan{
+				ID:         m.planCount,
+				Name:       input.Name,
+				SchemaSlug: input.SchemaSlug,
+				Status:     input.Status,
+				FromHash:   input.FromHash,
+				ToHash:     input.ToHash,
+				Migration:  input.Migration,
+				Link:       link,
+				URL:        url,
+			}
+			m.plans[input.Name] = plan
+			hash := fmt.Sprintf("%s-%s", input.FromHash, input.ToHash)
+			m.planFromHashes[hash] = append(m.planFromHashes[hash], plan)
+			fmt.Fprintf(w, `{"data":{"CreateDeclarativePlan": {"link": %q, "url": %q}}}`, link, url)
+		case strings.Contains(query.Query, "DeclarativePlanByHashes"):
+			require.NoError(t, json.Unmarshal(query.Variables, &query.DeclarativePlanByHashesVariables))
+			input := query.DeclarativePlanByHashesVariables.DeclarativePlanByHashesInput
+			hash := fmt.Sprintf("%s-%s", input.FromHash, input.ToHash)
+			plan, ok := m.planFromHashes[hash]
+			if !ok {
+				fmt.Fprintf(w, `{"data":{"DeclarativePlanByHashes": []}}`)
+				return
+			}
+			fmt.Fprintf(w, `{"data":{"DeclarativePlanByHashes": %s}}`, must(json.Marshal(plan)))
+		case strings.Contains(query.Query, "DeclarativePlanByName"):
+			require.NoError(t, json.Unmarshal(query.Variables, &query.DeclarativePlanByNameVariables))
+			input := query.DeclarativePlanByNameVariables.DeclarativePlanByNameInput
+			plan, ok := m.plans[input.Name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			fmt.Fprintf(w, `{"data":{"DeclarativePlanByName": %s}}`, must(json.Marshal(plan)))
+		}
+	}))
+}
+
+func must(b []byte, err error) []byte {
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -256,11 +256,9 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 			attrBoolPtr(b, v.ModifyForeignKey, "modify_foreign_key")
 		}
 	}
-	if ld := env.Lint; ld != nil {
+	if ld := env.Lint; ld != nil && !ld.Review.IsNull() {
 		l := e.AppendNewBlock("lint", nil).Body()
-		if r := ld.Review; !r.IsNull() {
-			l.SetAttributeValue("review", cty.StringVal(r.ValueString()))
-		}
+		l.SetAttributeValue("review", cty.StringVal(ld.Review.ValueString()))
 	}
 	return blk
 }

--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -101,10 +101,85 @@ func (c *projectConfig) LintReview() (*string, error) {
 	}
 	if reviewAttr := lintBlk.Body().GetAttribute("review"); reviewAttr != nil {
 		review := string(reviewAttr.Expr().BuildTokens(nil).Bytes())
-		trimmed := strings.Trim(review, `"`)
+		trimmed := strings.Trim(strings.TrimSpace(review), `"`)
 		return &trimmed, nil
 	}
 	return nil, nil
+}
+
+// TargetURL returns the target URL for the environment.
+func (c *projectConfig) TargetURL() (string, error) {
+	file, err := c.AsFile()
+	if err != nil {
+		return "", err
+	}
+	envBlk, err := searchBlock(file.Body(), "env", c.EnvName)
+	if err != nil || envBlk == nil {
+		return "", err
+	}
+	if envBlk.Body().GetAttribute("src") != nil {
+		return "env://src", nil
+	}
+	schemaBlk, err := searchBlock(envBlk.Body(), "schema", "")
+	if err != nil || schemaBlk == nil {
+		return "", err
+	}
+	if schemaBlk.Body().GetAttribute("src") != nil {
+		return "env://schema.src", nil
+	}
+	return "", nil
+}
+
+// RepoURL returns the repository URL for the environment.
+func (c *projectConfig) RepoURL() (*url.URL, error) {
+	switch {
+	// The user has provided the repository name in migration block.
+	case c.Env.Migration != nil && c.Env.Migration.Repo != "":
+		return &url.URL{
+			Scheme: SchemaTypeAtlas,
+			Host:   c.Env.Migration.Repo,
+		}, nil
+	// The user has provided the repository name in schema block.
+	case c.Env.Schema != nil && c.Env.Schema.Repo != "":
+		return &url.URL{
+			Scheme: SchemaTypeAtlas,
+			Host:   c.Env.Schema.Repo,
+		}, nil
+	// Fallback to desired URL if it's Cloud URL.
+	case c.Env.URL != "":
+		u, err := url.Parse(c.Env.URL)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != SchemaTypeAtlas {
+			return nil, nil
+		}
+		c := *u
+		c.RawQuery = ""
+		return &c, nil
+	// Search Repo URL in the project config.
+	default:
+		file, err := c.AsFile()
+		if err != nil {
+			return nil, err
+		}
+		envBlk, err := searchBlock(file.Body(), "env", c.EnvName)
+		if err != nil || envBlk == nil {
+			return nil, err
+		}
+		schemaBlk, err := searchBlock(envBlk.Body(), "schema", "")
+		if err != nil || schemaBlk == nil {
+			return nil, err
+		}
+		if schemaBlk.Body().GetAttribute("repo") != nil {
+			// Build Repo URL from env.
+			return &url.URL{
+				Scheme: "env",
+				Host:   "schema.repo",
+			}, nil
+		}
+		return nil, nil
+	}
 }
 
 // AsBlock returns the HCL block for the environment configuration.
@@ -118,7 +193,15 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 		e.SetAttributeValue("dev", cty.StringVal(env.DevURL))
 	}
 	if env.Source != "" {
-		e.SetAttributeValue("src", cty.StringVal(env.Source))
+		// src, schema attributes/blocks are mutually exclusive
+		if sc := env.Schema; sc != nil && sc.Repo != "" {
+			schema := e.AppendNewBlock("schema", nil).Body()
+			schema.SetAttributeValue("src", cty.StringVal(env.Source))
+			repo := schema.AppendNewBlock("repo", nil).Body()
+			repo.SetAttributeValue("name", cty.StringVal(sc.Repo))
+		} else {
+			e.SetAttributeValue("src", cty.StringVal(env.Source))
+		}
 	}
 	if l := deleteZero(env.Schemas); len(l) > 0 {
 		e.SetAttributeValue("schemas", listStringVal(l))
@@ -145,13 +228,6 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 		if md.Repo != "" {
 			repo := m.AppendNewBlock("repo", nil).Body()
 			repo.SetAttributeValue("name", cty.StringVal(md.Repo))
-		}
-	}
-	if sc := env.Schema; sc != nil {
-		if sc.Repo != "" {
-			schema := e.AppendNewBlock("schema", nil).Body()
-			repo := schema.AppendNewBlock("repo", nil).Body()
-			repo.SetAttributeValue("name", cty.StringVal(sc.Repo))
 		}
 	}
 	if dd := env.Diff; dd != nil {

--- a/internal/provider/builder_test.go
+++ b/internal/provider/builder_test.go
@@ -194,9 +194,9 @@ func Test_SchemaTemplate(t *testing.T) {
 				},
 			},
 			expected: `env "tf" {
-  src = "file://schema.hcl"
   url = "mysql://user:pass@localhost:3306/tf-db"
   schema {
+    src = "file://schema.hcl"
     repo {
       name = "test"
     }


### PR DESCRIPTION
This pull request adds an approval flow when applying `atlas_schema` resources. Based on the lint policy, the process will exit and wait for approval before continuing, depending on the severity level you set

### Usage

- To enable the review flow, set the `lint.review` option to one of the following values: `ALWAYS`, `ERROR`, or `WARNING`:

  - `ALWAYS`: Triggers an approval plan for every schema change.
  - `ERROR`/`WARNING`: Triggers an approval plan only when the schema change violates the corresponding lint policy.

```hcl
resource "atlas_schema" "db" {
  lint {
    review = "ALWAYS" //  "ALWAYS", "ERROR", "WARNING"
  }
}
```

- To control the timeout of approval process, set `lint.review_timeout`. Default to `0s`

```hcl
resource "atlas_schema" "db" {
  lint {
    review = "ALWAYS"
    review_timeout = "1m"
  }
}
```

### Demo

When `lint.review` is enabled, the provider will automatically create a plan and require user approval before proceeding. If `review_timeout` is not set, the process will throw an error immediately:

![Screenshot 2025-04-14 at 13 22 09](https://github.com/user-attachments/assets/622108f1-1e18-4c7c-bd2c-bdf06c52f7c5)

https://github.com/user-attachments/assets/dc92e6d6-6433-4f59-a6c9-5d9c8c856ba1

If `lint.review_timeout` is set, the process will wait for the plan to be approved before continuing to apply the schema.

https://github.com/user-attachments/assets/e75dd1df-1ed8-4892-92b1-8ad698572f91

If `lint.review_timeout` is set and the timeout is reached before approval, an error will be displayed:

![Screenshot 2025-04-14 at 14 24 31](https://github.com/user-attachments/assets/b28507d8-7706-42d3-b1d2-d9fe4b97981b)







