### PR TITLE
internal/provider: rename 'project' to 'repo' in migration and schema resources

### DIFF
--- a/docs/data-sources/migration.md
+++ b/docs/data-sources/migration.md
@@ -46,7 +46,8 @@ data "atlas_migration" "hello" {
 
 Optional:
 
-- `project` (String)
+- `project` (String, Deprecated)
+- `repo` (String)
 - `token` (String)
 - `url` (String)
 

--- a/docs/data-sources/schema.md
+++ b/docs/data-sources/schema.md
@@ -44,9 +44,20 @@ resource "atlas_schema" "hello" {
 
 ### Optional
 
+- `cloud` (Block, Optional) (see [below for nested schema](#nestedblock--cloud))
 - `variables` (Map of String) The map of variables used in the HCL.
 
 ### Read-Only
 
 - `hcl` (String) The normalized form of the HCL
 - `id` (String) The ID of this resource
+
+<a id="nestedblock--cloud"></a>
+### Nested Schema for `cloud`
+
+Optional:
+
+- `project` (String, Deprecated)
+- `repo` (String)
+- `token` (String)
+- `url` (String)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ resource "atlas_schema" "market" {
 
 Optional:
 
-- `project` (String)
+- `project` (String, Deprecated)
+- `repo` (String)
 - `token` (String)
 - `url` (String)

--- a/docs/resources/migration.md
+++ b/docs/resources/migration.md
@@ -55,7 +55,8 @@ resource "atlas_migration" "hello" {
 
 Optional:
 
-- `project` (String)
+- `project` (String, Deprecated)
+- `repo` (String)
 - `token` (String)
 - `url` (String)
 

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -33,6 +33,7 @@ resource "atlas_schema" "market" {
 
 ### Optional
 
+- `cloud` (Block, Optional) (see [below for nested schema](#nestedblock--cloud))
 - `config` (String) The content of atlas.hcl config
 - `dev_url` (String, Sensitive) The url of the dev-db see https://atlasgo.io/cli/url
 - `diff` (Block, Optional) (see [below for nested schema](#nestedblock--diff))
@@ -46,6 +47,17 @@ resource "atlas_schema" "market" {
 ### Read-Only
 
 - `id` (String) The ID of this resource
+
+<a id="nestedblock--cloud"></a>
+### Nested Schema for `cloud`
+
+Optional:
+
+- `project` (String, Deprecated)
+- `repo` (String)
+- `token` (String)
+- `url` (String)
+
 
 <a id="nestedblock--diff"></a>
 ### Nested Schema for `diff`

--- a/internal/provider/atlas_migration_data_source.go
+++ b/internal/provider/atlas_migration_data_source.go
@@ -239,6 +239,7 @@ func (d *MigrationDataSourceModel) Workspace(ctx context.Context, p *ProviderDat
 			DevURL: p.DevURL,
 			Migration: &migrationConfig{
 				RevisionsSchema: d.RevisionsSchema.ValueString(),
+				Repo:            repoConfig(p.Cloud),
 			},
 		},
 	}

--- a/internal/provider/atlas_migration_resource.go
+++ b/internal/provider/atlas_migration_resource.go
@@ -775,6 +775,7 @@ func (d *MigrationResourceModel) Workspace(ctx context.Context, p *ProviderData)
 				Baseline:        d.Baseline.ValueString(),
 				RevisionsSchema: d.RevisionsSchema.ValueString(),
 				ExecOrder:       d.ExecOrder.ValueString(),
+				Repo:            repoConfig(p.Cloud),
 			},
 		},
 	}

--- a/internal/provider/atlas_schema_data_source.go
+++ b/internal/provider/atlas_schema_data_source.go
@@ -28,6 +28,8 @@ type (
 		HCL       types.String `tfsdk:"hcl"`
 		ID        types.String `tfsdk:"id"`
 		Variables types.Map    `tfsdk:"variables"`
+		// Cloud config
+		Cloud *AtlasCloudBlock `tfsdk:"cloud"`
 	}
 )
 
@@ -54,6 +56,9 @@ func (d *AtlasSchemaDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 		// This description is used by the documentation generator and the language server.
 		Description: "atlas_schema data source uses dev-db to normalize the HCL schema " +
 			"in order to create better terraform diffs",
+		Blocks: map[string]schema.Block{
+			"cloud": cloudBlock,
+		},
 		Attributes: map[string]schema.Attribute{
 			"dev_url": schema.StringAttribute{
 				Description: "The url of the dev-db see https://atlasgo.io/cli/url",
@@ -154,6 +159,9 @@ func (d *AtlasSchemaDataSourceModel) Workspace(ctx context.Context, p *ProviderD
 		Env: &envConfig{
 			URL:    "file://schema.hcl",
 			DevURL: defaultString(d.DevURL, p.DevURL),
+			Schema: &schemaConfig{
+				Repo: repoConfig(p.Cloud),
+			},
 		},
 	}
 	opts := []atlas.Option{atlas.WithAtlasHCL(cfg.Render)}

--- a/internal/provider/atlas_schema_resource.go
+++ b/internal/provider/atlas_schema_resource.go
@@ -43,6 +43,8 @@ type (
 		Config  types.String `tfsdk:"config"`
 		Vars    types.String `tfsdk:"variables"`
 		EnvName types.String `tfsdk:"env_name"`
+		// Cloud config
+		Cloud *AtlasCloudBlock `tfsdk:"cloud"`
 	}
 	// Diff defines the diff policies to apply when planning schema changes.
 	Diff struct {
@@ -156,8 +158,9 @@ func (r *AtlasSchemaResource) Schema(ctx context.Context, _ resource.SchemaReque
 			"using an HCL file describing the wanted state of the database. " +
 			"See https://atlasgo.io/",
 		Blocks: map[string]schema.Block{
-			"diff": diffBlock,
-			"lint": lintBlock,
+			"diff":  diffBlock,
+			"lint":  lintBlock,
+			"cloud": cloudBlock,
 		},
 		Attributes: map[string]schema.Attribute{
 			"hcl": schema.StringAttribute{
@@ -504,6 +507,9 @@ func (d *AtlasSchemaResourceModel) Workspace(ctx context.Context, p *ProviderDat
 			Source: "file://schema.hcl",
 			Diff:   d.Diff,
 			Lint:   d.Lint,
+			Schema: &schemaConfig{
+				Repo: repoConfig(p.Cloud),
+			},
 		},
 	}
 	if cloud := p.Cloud; cloud.Valid() {

--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -43,6 +43,7 @@ type (
 		Diff      *Diff
 		Lint      *Lint
 		Migration *migrationConfig
+		Schema    *schemaConfig
 	}
 	CloudConfig struct {
 		Token string
@@ -52,6 +53,10 @@ type (
 		Baseline        string
 		ExecOrder       string
 		RevisionsSchema string
+		Repo            string
+	}
+	schemaConfig struct {
+		Repo string
 	}
 )
 
@@ -136,6 +141,15 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 		}
 		if md.RevisionsSchema != "" {
 			m.SetAttributeValue("revisions_schema", cty.StringVal(md.RevisionsSchema))
+		}
+		if md.Repo != "" {
+			m.SetAttributeValue("repo", cty.StringVal(md.Repo))
+		}
+	}
+	if sc := env.Schema; sc != nil {
+		if sc.Repo != "" {
+			schema := e.AppendNewBlock("schema", nil).Body()
+			schema.SetAttributeValue("repo", cty.StringVal(sc.Repo))
 		}
 	}
 	if dd := env.Diff; dd != nil {

--- a/internal/provider/builder_test.go
+++ b/internal/provider/builder_test.go
@@ -156,6 +156,50 @@ func Test_SchemaTemplate(t *testing.T) {
 }
 `,
 		},
+		{
+			name: "migration-repo",
+			data: &projectConfig{
+				Config:  "",
+				EnvName: "tf",
+				Env: &envConfig{
+					Source: "file://schema.hcl",
+					URL:    "mysql://user:pass@localhost:3306/tf-db",
+					Migration: &migrationConfig{
+						Repo: "test",
+					},
+				},
+			},
+			expected: `env "tf" {
+  src = "file://schema.hcl"
+  url = "mysql://user:pass@localhost:3306/tf-db"
+  migration {
+    repo = "test"
+  }
+}
+`,
+		},
+		{
+			name: "schema-repo",
+			data: &projectConfig{
+				Config:  "",
+				EnvName: "tf",
+				Env: &envConfig{
+					Source: "file://schema.hcl",
+					URL:    "mysql://user:pass@localhost:3306/tf-db",
+					Schema: &schemaConfig{
+						Repo: "test",
+					},
+				},
+			},
+			expected: `env "tf" {
+  src = "file://schema.hcl"
+  url = "mysql://user:pass@localhost:3306/tf-db"
+  schema {
+    repo = "test"
+  }
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request replaces the `project` attribute with the `repo` attribute and add support for rendering `atlas.hcl` for this field. There are no breaking changes, as the `project` attribute was previously unused in any logic.