### PR TITLE
internal/provider: enhance schema apply with approval flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,19 @@ jobs:
           ! cat stdout.txt | grep --silent "Warning: version is unset"
         env:
           TF_VAR_atlas_token: ${{ secrets.ATLAS_TOKEN }}
+      - name: Terraform (review)
+        working-directory: integration-tests/review
+        run: |
+          ../../scripts/local.sh ../../dist 0.0.0-pre.0
+          terraform init > /dev/null
+          echo "Apply terraform plan"
+          terraform apply -no-color --auto-approve > stdout.txt
+          cat stdout.txt | grep --silent "Apply complete! Resources: 1 added, 0 changed, 0 destroyed."
+          echo "Ensure that there is no diff"
+          terraform plan -no-color > stdout.txt
+          cat stdout.txt | grep --silent "No changes. Your infrastructure matches the configuration."
+        env:
+          TF_VAR_atlas_token: ${{ secrets.ATLAS_TOKEN }}
   integration-mysql:
     name: Integration MySQL (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -105,3 +105,4 @@ Optional:
 Optional:
 
 - `review` (String) The review policy
+- `review_timeout` (String) The review timeout

--- a/integration-tests/review/main.tf
+++ b/integration-tests/review/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    atlas = {
+      source  = "ariga/atlas"
+      version = "0.0.0-pre.0"
+    }
+  }
+}
+
+variable "atlas_token" {
+  type      = string
+  sensitive = true
+}
+
+provider "atlas" {
+  cloud {
+    token = var.atlas_token
+  }
+}
+
+resource "atlas_schema" "db" {
+  hcl = <<-EOT
+    table "t1" {
+      schema = schema.main
+      column "c1" {
+        null = false
+        type = int
+      }
+    }
+    schema "main" {
+    }
+  EOT
+  lint {
+    review = "ALWAYS"
+  }
+  cloud {
+    repo = "atlas-terraform"
+  }
+  url = "sqlite://example.db"
+  dev_url = "sqlite://test.db?mode=memory"
+}

--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -101,10 +101,85 @@ func (c *projectConfig) LintReview() (*string, error) {
 	}
 	if reviewAttr := lintBlk.Body().GetAttribute("review"); reviewAttr != nil {
 		review := string(reviewAttr.Expr().BuildTokens(nil).Bytes())
-		trimmed := strings.Trim(review, `"`)
+		trimmed := strings.Trim(strings.TrimSpace(review), `"`)
 		return &trimmed, nil
 	}
 	return nil, nil
+}
+
+// TargetURL returns the target URL for the environment.
+func (c *projectConfig) TargetURL() (string, error) {
+	file, err := c.AsFile()
+	if err != nil {
+		return "", err
+	}
+	envBlk, err := searchBlock(file.Body(), "env", c.EnvName)
+	if err != nil || envBlk == nil {
+		return "", err
+	}
+	if envBlk.Body().GetAttribute("src") != nil {
+		return "env://src", nil
+	}
+	schemaBlk, err := searchBlock(envBlk.Body(), "schema", "")
+	if err != nil || schemaBlk == nil {
+		return "", err
+	}
+	if schemaBlk.Body().GetAttribute("src") != nil {
+		return "env://schema.src", nil
+	}
+	return "", nil
+}
+
+// RepoURL returns the repository URL for the environment.
+func (c *projectConfig) RepoURL() (*url.URL, error) {
+	switch {
+	// The user has provided the repository name in migration block.
+	case c.Env.Migration != nil && c.Env.Migration.Repo != "":
+		return &url.URL{
+			Scheme: SchemaTypeAtlas,
+			Host:   c.Env.Migration.Repo,
+		}, nil
+	// The user has provided the repository name in schema block.
+	case c.Env.Schema != nil && c.Env.Schema.Repo != "":
+		return &url.URL{
+			Scheme: SchemaTypeAtlas,
+			Host:   c.Env.Schema.Repo,
+		}, nil
+	// Fallback to desired URL if it's Cloud URL.
+	case c.Env.URL != "":
+		u, err := url.Parse(c.Env.URL)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != SchemaTypeAtlas {
+			return nil, nil
+		}
+		c := *u
+		c.RawQuery = ""
+		return &c, nil
+	// Search Repo URL in the project config.
+	default:
+		file, err := c.AsFile()
+		if err != nil {
+			return nil, err
+		}
+		envBlk, err := searchBlock(file.Body(), "env", c.EnvName)
+		if err != nil || envBlk == nil {
+			return nil, err
+		}
+		schemaBlk, err := searchBlock(envBlk.Body(), "schema", "")
+		if err != nil || schemaBlk == nil {
+			return nil, err
+		}
+		if schemaBlk.Body().GetAttribute("repo") != nil {
+			// Build Repo URL from env.
+			return &url.URL{
+				Scheme: "env",
+				Host:   "schema.repo",
+			}, nil
+		}
+		return nil, nil
+	}
 }
 
 // AsBlock returns the HCL block for the environment configuration.
@@ -118,7 +193,15 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 		e.SetAttributeValue("dev", cty.StringVal(env.DevURL))
 	}
 	if env.Source != "" {
-		e.SetAttributeValue("src", cty.StringVal(env.Source))
+		// src, schema attributes/blocks are mutually exclusive
+		if sc := env.Schema; sc != nil && sc.Repo != "" {
+			schema := e.AppendNewBlock("schema", nil).Body()
+			schema.SetAttributeValue("src", cty.StringVal(env.Source))
+			repo := schema.AppendNewBlock("repo", nil).Body()
+			repo.SetAttributeValue("name", cty.StringVal(sc.Repo))
+		} else {
+			e.SetAttributeValue("src", cty.StringVal(env.Source))
+		}
 	}
 	if l := deleteZero(env.Schemas); len(l) > 0 {
 		e.SetAttributeValue("schemas", listStringVal(l))
@@ -147,13 +230,6 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 			repo.SetAttributeValue("name", cty.StringVal(md.Repo))
 		}
 	}
-	if sc := env.Schema; sc != nil {
-		if sc.Repo != "" {
-			schema := e.AppendNewBlock("schema", nil).Body()
-			repo := schema.AppendNewBlock("repo", nil).Body()
-			repo.SetAttributeValue("name", cty.StringVal(sc.Repo))
-		}
-	}
 	if dd := env.Diff; dd != nil {
 		d := e.AppendNewBlock("diff", nil).Body()
 		if v := dd.ConcurrentIndex; v != nil {
@@ -180,11 +256,9 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 			attrBoolPtr(b, v.ModifyForeignKey, "modify_foreign_key")
 		}
 	}
-	if ld := env.Lint; ld != nil {
+	if ld := env.Lint; ld != nil && !ld.Review.IsNull() {
 		l := e.AppendNewBlock("lint", nil).Body()
-		if r := ld.Review; !r.IsNull() {
-			l.SetAttributeValue("review", cty.StringVal(r.ValueString()))
-		}
+		l.SetAttributeValue("review", cty.StringVal(ld.Review.ValueString()))
 	}
 	return blk
 }

--- a/internal/provider/builder_test.go
+++ b/internal/provider/builder_test.go
@@ -194,9 +194,9 @@ func Test_SchemaTemplate(t *testing.T) {
 				},
 			},
 			expected: `env "tf" {
-  src = "file://schema.hcl"
   url = "mysql://user:pass@localhost:3306/tf-db"
   schema {
+    src = "file://schema.hcl"
     repo {
       name = "test"
     }


### PR DESCRIPTION
This pull request adds an approval flow when applying `atlas_schema` resources. Based on the lint policy, the process will exit and wait for approval before continuing, depending on the severity level you set

### Usage

- To enable the review flow, set the `lint.review` option to one of the following values: `ALWAYS`, `ERROR`, or `WARNING`:

  - `ALWAYS`: Triggers an approval plan for every schema change.
  - `ERROR`/`WARNING`: Triggers an approval plan only when the schema change violates the corresponding lint policy.

```hcl
resource "atlas_schema" "db" {
  lint {
    review = "ALWAYS" //  "ALWAYS", "ERROR", "WARNING"
  }
}
```

- To control the timeout of approval process, set `lint.review_timeout`. Default to `0s`

```hcl
resource "atlas_schema" "db" {
  lint {
    review = "ALWAYS"
    review_timeout = "1m"
  }
}
```

### Demo

When `lint.review` is enabled, the provider will automatically create a plan and require user approval before proceeding. If `review_timeout` is not set, the process will throw an error immediately:

![Screenshot 2025-04-14 at 13 22 09](https://github.com/user-attachments/assets/622108f1-1e18-4c7c-bd2c-bdf06c52f7c5)

https://github.com/user-attachments/assets/dc92e6d6-6433-4f59-a6c9-5d9c8c856ba1

If `lint.review_timeout` is set, the process will wait for the plan to be approved before continuing to apply the schema.

https://github.com/user-attachments/assets/e75dd1df-1ed8-4892-92b1-8ad698572f91

If `lint.review_timeout` is set and the timeout is reached before approval, an error will be displayed:

![Screenshot 2025-04-14 at 14 24 31](https://github.com/user-attachments/assets/b28507d8-7706-42d3-b1d2-d9fe4b97981b)







