### PR TITLE
internal/provider: add support for exclude/include attributes in migration and schema data sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,20 @@ jobs:
           echo "Ensure that there is no diff"
           terraform plan -no-color > stdout.txt
           cat stdout.txt | grep --silent "No changes. Your infrastructure matches the configuration."
+      - name: Terraform (exclude)
+        working-directory: integration-tests/exclude
+        run: |
+          ../../scripts/local.sh ../../dist 0.0.0-pre.0
+          terraform init
+          echo "Apply terraform plan"
+          terraform apply -no-color --auto-approve > stdout.txt
+          cat stdout.txt | grep --silent "Apply complete! Resources: 1 added, 0 changed, 0 destroyed."
+          echo "Ensure that t2 is excluded from the HCL"
+          terraform show -no-color | grep --silent 'table "t1"'
+          ! terraform show -no-color | grep --silent 'table "t2"'
+          echo "Ensure that there is no diff"
+          terraform plan -no-color > stdout.txt
+          cat stdout.txt | grep --silent "No changes. Your infrastructure matches the configuration."
       - name: Terraform (no-dev-url)
         working-directory: integration-tests/no-dev-url
         run: |

--- a/docs/data-sources/migration.md
+++ b/docs/data-sources/migration.md
@@ -29,6 +29,8 @@ data "atlas_migration" "hello" {
 - `dev_url` (String, Sensitive) The URL of the dev-db. See https://atlasgo.io/cli/url
 - `dir` (String) Select migration directory using URL format
 - `env_name` (String) The name of the environment used for reporting runs to Atlas Cloud. Default: tf
+- `exclude` (List of String) Filter out resources matching the given glob pattern. See https://atlasgo.io/declarative/inspect#exclude
+- `include` (List of String) Include only resources that match the given glob pattern. See https://atlasgo.io/declarative/inspect#include
 - `remote_dir` (Block, Optional, Deprecated) (see [below for nested schema](#nestedblock--remote_dir))
 - `revisions_schema` (String) The name of the schema the revisions table resides in
 - `url` (String, Sensitive) [driver://username:password@address/dbname?param=value] select a resource using the URL format

--- a/docs/data-sources/schema.md
+++ b/docs/data-sources/schema.md
@@ -47,6 +47,8 @@ resource "atlas_schema" "hello" {
 - `config` (String) Atlas HCL configuration content. Use abspath(path.module) when referencing local files or directories, for example: `file://${abspath(path.module)}/migrations`. See https://atlasgo.io/hcl/config
 - `dev_url` (String, Sensitive) The url of the dev-db see https://atlasgo.io/cli/url
 - `env_name` (String) The name of the environment to be picked from the Atlas configuration. Default: tf
+- `exclude` (List of String) Filter out resources matching the given glob pattern. See https://atlasgo.io/declarative/inspect#exclude
+- `include` (List of String) Include only resources that match the given glob pattern. See https://atlasgo.io/declarative/inspect#include
 - `variables` (Map of String) The map of variables used in the Atlas configuration
 
 ### Read-Only

--- a/integration-tests/exclude/main.tf
+++ b/integration-tests/exclude/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    atlas = {
+      source  = "ariga/atlas"
+      version = "0.0.0-pre.0"
+    }
+  }
+}
+
+# Data source with exclude: filters out t2 table from normalization
+data "atlas_schema" "db" {
+  src     = "file://schema.sql"
+  dev_url = "sqlite://file?mode=memory"
+  exclude = ["t2"]
+}
+
+# Resource with exclude: applies only t1, ignoring t2 on the target
+resource "atlas_schema" "db" {
+  hcl     = data.atlas_schema.db.hcl
+  url     = "sqlite://file.db"
+  dev_url = "sqlite://file?mode=memory"
+  exclude = ["t2"]
+}

--- a/integration-tests/exclude/schema.sql
+++ b/integration-tests/exclude/schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE t1 (
+  c1 INT,
+  c2 TEXT,
+  PRIMARY KEY (c1)
+);
+CREATE TABLE t2 (
+  c1 INT,
+  PRIMARY KEY (c1)
+);

--- a/internal/provider/atlas_migration_data_source.go
+++ b/internal/provider/atlas_migration_data_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -29,6 +30,8 @@ type (
 		URL             types.String `tfsdk:"url"`
 		DevURL          types.String `tfsdk:"dev_url"`
 		RevisionsSchema types.String `tfsdk:"revisions_schema"`
+		Exclude         types.List   `tfsdk:"exclude"`
+		Include         types.List   `tfsdk:"include"`
 
 		DirURL    types.String     `tfsdk:"dir"`
 		Cloud     *AtlasCloudBlock `tfsdk:"cloud"`
@@ -134,6 +137,16 @@ func (d *MigrationDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 			},
 			"dir": schema.StringAttribute{
 				Description: "Select migration directory using URL format",
+				Optional:    true,
+			},
+			"exclude": schema.ListAttribute{
+				Description: "Filter out resources matching the given glob pattern. See https://atlasgo.io/declarative/inspect#exclude",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"include": schema.ListAttribute{
+				Description: "Include only resources that match the given glob pattern. See https://atlasgo.io/declarative/inspect#include",
+				ElementType: types.StringType,
 				Optional:    true,
 			},
 			"env_name": schema.StringAttribute{
@@ -252,6 +265,18 @@ func (d *MigrationDataSourceModel) Workspace(ctx context.Context, p *ProviderDat
 			URL:    dbURL,
 			DevURL: defaultString(d.DevURL, p.DevURL),
 		},
+	}
+	if !d.Exclude.IsNull() && !d.Exclude.IsUnknown() {
+		diags := d.Exclude.ElementsAs(ctx, &cfg.Env.Exclude, false)
+		if diags.HasError() {
+			return nil, nil, errors.New(diags.Errors()[0].Summary())
+		}
+	}
+	if !d.Include.IsNull() && !d.Include.IsUnknown() {
+		diags := d.Include.ElementsAs(ctx, &cfg.Env.Include, false)
+		if diags.HasError() {
+			return nil, nil, errors.New(diags.Errors()[0].Summary())
+		}
 	}
 	m := migrationConfig{
 		RevisionsSchema: d.RevisionsSchema.ValueString(),

--- a/internal/provider/atlas_migration_data_source_test.go
+++ b/internal/provider/atlas_migration_data_source_test.go
@@ -262,6 +262,58 @@ HCL
 	})
 }
 
+func TestAccMigrationDataSource_Exclude(t *testing.T) {
+	schema := "test"
+	tempSchemas(t, mysqlURL, schema)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				data "atlas_migration" "hello" {
+					dir     = "migrations?format=atlas"
+					url     = "%s/%s"
+					exclude = ["*.bar"]
+				}
+				`, mysqlURL, schema),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "status", "PENDING"),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "current", ""),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "next", "20221101163823"),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "latest", "20221101165415"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMigrationDataSource_Include(t *testing.T) {
+	schema := "test"
+	tempSchemas(t, mysqlURL, schema)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				data "atlas_migration" "hello" {
+					dir     = "migrations?format=atlas"
+					url     = "%s/%s"
+					include = ["*.foo"]
+				}
+				`, mysqlURL, schema),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "status", "PENDING"),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "current", ""),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "next", "20221101163823"),
+					resource.TestCheckResourceAttr("data.atlas_migration.hello", "latest", "20221101165415"),
+				),
+			},
+		},
+	})
+}
+
 func writeDir(t *testing.T, dir migrate.Dir, w io.Writer) {
 	// Checksum before archiving.
 	hf, err := dir.Checksum()

--- a/internal/provider/atlas_schema_data_source.go
+++ b/internal/provider/atlas_schema_data_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"net/url"
@@ -23,10 +24,12 @@ type (
 	}
 	// AtlasSchemaDataSourceModel describes the data source data model.
 	AtlasSchemaDataSourceModel struct {
-		DevURL types.String `tfsdk:"dev_url"`
-		Src    types.String `tfsdk:"src"`
-		HCL    types.String `tfsdk:"hcl"`
-		ID     types.String `tfsdk:"id"`
+		DevURL  types.String `tfsdk:"dev_url"`
+		Src     types.String `tfsdk:"src"`
+		HCL     types.String `tfsdk:"hcl"`
+		ID      types.String `tfsdk:"id"`
+		Exclude types.List   `tfsdk:"exclude"`
+		Include types.List   `tfsdk:"include"`
 		// Cloud config
 		Cloud *AtlasCloudBlock `tfsdk:"cloud"`
 
@@ -73,6 +76,16 @@ func (d *AtlasSchemaDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 				Description: "The schema definition of the database. This attribute can be HCL schema, " +
 					"a URL to HCL/SQL file (file://path), or a cloud schema URL (atlas://repo-name).",
 				Required: true,
+			},
+			"exclude": schema.ListAttribute{
+				Description: "Filter out resources matching the given glob pattern. See https://atlasgo.io/declarative/inspect#exclude",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"include": schema.ListAttribute{
+				Description: "Include only resources that match the given glob pattern. See https://atlasgo.io/declarative/inspect#include",
+				ElementType: types.StringType,
+				Optional:    true,
 			},
 			// the HCL in a predicted, and ordered format see https://atlasgo.io/cli/dev-database
 			"hcl": schema.StringAttribute{
@@ -179,6 +192,18 @@ func (d *AtlasSchemaDataSourceModel) Workspace(ctx context.Context, p *ProviderD
 				Repo: repoConfig(d.Cloud, p.Cloud),
 			},
 		},
+	}
+	if !d.Exclude.IsNull() && !d.Exclude.IsUnknown() {
+		diags := d.Exclude.ElementsAs(ctx, &cfg.Env.Exclude, false)
+		if diags.HasError() {
+			return nil, nil, errors.New(diags.Errors()[0].Summary())
+		}
+	}
+	if !d.Include.IsNull() && !d.Include.IsUnknown() {
+		diags := d.Include.ElementsAs(ctx, &cfg.Env.Include, false)
+		if diags.HasError() {
+			return nil, nil, errors.New(diags.Errors()[0].Summary())
+		}
 	}
 	opts := []atlas.Option{atlas.WithAtlasHCL(cfg.Render)}
 	u, err := url.Parse(filepath.ToSlash(d.Src.ValueString()))

--- a/internal/provider/atlas_schema_data_source_internal_test.go
+++ b/internal/provider/atlas_schema_data_source_internal_test.go
@@ -15,6 +15,8 @@ func TestAtlasSchemaDataSource_WorkspaceConfig(t *testing.T) {
 		name        string
 		src         string
 		devURL      string
+		exclude     []string
+		include     []string
 		expected    string
 		expectedURL string // Expected RepoURL result
 	}{
@@ -51,6 +53,47 @@ func TestAtlasSchemaDataSource_WorkspaceConfig(t *testing.T) {
 `,
 			expectedURL: "", // No cloud URL for inline HCL
 		},
+		{
+			name:    "inline HCL with exclude",
+			src:     `schema "test" {}`,
+			devURL:  "docker://postgres/16/dev",
+			exclude: []string{"*.users"},
+			expected: `env "tf" {
+  dev     = "docker://postgres/16/dev"
+  exclude = ["*.users"]
+  url     = "file://schema.hcl"
+}
+`,
+			expectedURL: "",
+		},
+		{
+			name:    "inline HCL with include",
+			src:     `schema "test" {}`,
+			devURL:  "docker://postgres/16/dev",
+			include: []string{"public.*"},
+			expected: `env "tf" {
+  dev     = "docker://postgres/16/dev"
+  include = ["public.*"]
+  url     = "file://schema.hcl"
+}
+`,
+			expectedURL: "",
+		},
+		{
+			name:    "inline HCL with include and exclude",
+			src:     `schema "test" {}`,
+			devURL:  "docker://postgres/16/dev",
+			exclude: []string{"*.users"},
+			include: []string{"public.*"},
+			expected: `env "tf" {
+  dev     = "docker://postgres/16/dev"
+  exclude = ["*.users"]
+  include = ["public.*"]
+  url     = "file://schema.hcl"
+}
+`,
+			expectedURL: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -58,6 +101,16 @@ func TestAtlasSchemaDataSource_WorkspaceConfig(t *testing.T) {
 			data := &AtlasSchemaDataSourceModel{
 				Src:    types.StringValue(tt.src),
 				DevURL: types.StringValue(tt.devURL),
+			}
+			if tt.exclude != nil {
+				v, diags := types.ListValueFrom(context.Background(), types.StringType, tt.exclude)
+				require.False(t, diags.HasError())
+				data.Exclude = v
+			}
+			if tt.include != nil {
+				v, diags := types.ListValueFrom(context.Background(), types.StringType, tt.include)
+				require.False(t, diags.HasError())
+				data.Include = v
 			}
 			providerData := &ProviderData{}
 


### PR DESCRIPTION
This pull request adds support for `exclude` and `include` filters to both the `atlas_schema` and `atlas_migration` data sources and resources, allowing users to filter resources using glob patterns. The implementation includes changes to the provider code, documentation, integration tests, and acceptance tests to ensure correct behavior and coverage.