### PR TITLE
provider: always map atlas_schema.hcl to env.schema.src

### DIFF
--- a/internal/provider/builder.go
+++ b/internal/provider/builder.go
@@ -117,9 +117,6 @@ func (c *projectConfig) TargetURL() (string, error) {
 	if err != nil || envBlk == nil {
 		return "", err
 	}
-	if envBlk.Body().GetAttribute("src") != nil {
-		return "env://src", nil
-	}
 	schemaBlk, err := searchBlock(envBlk.Body(), "schema", "")
 	if err != nil || schemaBlk == nil {
 		return "", err
@@ -193,14 +190,11 @@ func (env *envConfig) AsBlock() *hclwrite.Block {
 		e.SetAttributeValue("dev", cty.StringVal(env.DevURL))
 	}
 	if env.Source != "" {
-		// src, schema attributes/blocks are mutually exclusive
+		schema := e.AppendNewBlock("schema", nil).Body()
+		schema.SetAttributeValue("src", cty.StringVal(env.Source))
 		if sc := env.Schema; sc != nil && sc.Repo != "" {
-			schema := e.AppendNewBlock("schema", nil).Body()
-			schema.SetAttributeValue("src", cty.StringVal(env.Source))
 			repo := schema.AppendNewBlock("repo", nil).Body()
 			repo.SetAttributeValue("name", cty.StringVal(sc.Repo))
-		} else {
-			e.SetAttributeValue("src", cty.StringVal(env.Source))
 		}
 	}
 	if l := deleteZero(env.Schemas); len(l) > 0 {
@@ -401,18 +395,25 @@ func mergeBlock(dst, src *hclwrite.Block) {
 		dstBody.SetAttributeRaw(name, attr.Expr().BuildTokens(nil))
 	}
 	srcBlocks := srcBody.Blocks()
-	srcBlockTypes := make(map[string]struct{})
+	// Index source blocks by type for matching.
+	srcByType := make(map[string]*hclwrite.Block)
 	for _, blk := range srcBlocks {
-		srcBlockTypes[blk.Type()] = struct{}{}
+		srcByType[blk.Type()] = blk
 	}
+	// Recursively merge blocks that exist in both dst and src.
 	for _, blk := range dstBody.Blocks() {
-		if _, conflict := srcBlockTypes[blk.Type()]; conflict {
-			// Remove the block from the destination if it already exists.
-			dstBody.RemoveBlock(blk)
+		if srcBlk, ok := srcByType[blk.Type()]; ok {
+			// Merge recursively instead of replacing. This allows users to provide a base config
+			// with some blocks and let the provider fill in the rest of the block.
+			mergeBlock(blk, srcBlk)
+			delete(srcByType, blk.Type())
 		}
 	}
+	// Append source blocks that had no match in dst.
 	for _, blk := range srcBlocks {
-		appendBlock(dstBody, blk)
+		if _, ok := srcByType[blk.Type()]; ok {
+			appendBlock(dstBody, blk)
+		}
 	}
 }
 

--- a/internal/provider/builder_test.go
+++ b/internal/provider/builder_test.go
@@ -155,8 +155,10 @@ func Test_SchemaTemplate(t *testing.T) {
 			},
 			expected: `env "tf" {
   dev = "mysql://user:pass@localhost:3307/tf-db"
-  src = "file://schema.hcl"
   url = "mysql://user:pass@localhost:3306/tf-db"
+  schema {
+    src = "file://schema.hcl"
+  }
   diff {
     concurrent_index {
       create = true
@@ -186,8 +188,10 @@ func Test_SchemaTemplate(t *testing.T) {
 				},
 			},
 			expected: `env "tf" {
-  src = "file://schema.hcl"
   url = "mysql://user:pass@localhost:3306/tf-db"
+  schema {
+    src = "file://schema.hcl"
+  }
   migration {
     repo {
       name = "test"
@@ -217,6 +221,77 @@ func Test_SchemaTemplate(t *testing.T) {
       name = "test"
     }
   }
+}
+`,
+		},
+		{
+			name: "user-schema-mode-no-repo",
+			data: &projectConfig{
+				Config: `env "tf" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+  }
+}
+`,
+				EnvName: "tf",
+				Env: &envConfig{
+					Source: "file://schema.hcl",
+					URL:    "postgres://localhost:5432/db",
+					DevURL: "docker://postgres/15/dev?search_path=public",
+					Schema: &schemaConfig{},
+				},
+			},
+			expected: `env "tf" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+    src = "file://schema.hcl"
+  }
+  dev = "docker://postgres/15/dev?search_path=public"
+  url = "postgres://localhost:5432/db"
+}
+`,
+		},
+		{
+			name: "user-schema-mode-with-repo",
+			data: &projectConfig{
+				Config: `env "tf" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+  }
+}
+`,
+				EnvName: "tf",
+				Env: &envConfig{
+					Source: "file://schema.hcl",
+					URL:    "postgres://localhost:5432/db",
+					DevURL: "docker://postgres/15/dev?search_path=public",
+					Schema: &schemaConfig{
+						Repo: "roles-repo",
+					},
+				},
+			},
+			expected: `env "tf" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+    src = "file://schema.hcl"
+    repo {
+      name = "roles-repo"
+    }
+  }
+  dev = "docker://postgres/15/dev?search_path=public"
+  url = "postgres://localhost:5432/db"
 }
 `,
 		},
@@ -327,6 +402,77 @@ env {
   migration {
     dir = "file://migrations"
   }
+}
+`, string(dst.Bytes()))
+
+	// Merge schema block preserving user's mode block.
+	schemaEnvBlock := (&envConfig{
+		URL:    "postgres://localhost:5432/db",
+		DevURL: "docker://postgres/15/dev?search_path=public",
+		Source: "file://schema.hcl",
+		Schema: &schemaConfig{},
+	}).AsBlock()
+
+	dst, err = parseConfig(`
+env "roles" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+  }
+}
+`)
+	require.NoError(t, err)
+	require.NoError(t, mergeEnvBlock(dst.Body(), schemaEnvBlock, "roles"))
+	require.Equal(t, `
+env "roles" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+    src = "file://schema.hcl"
+  }
+  dev = "docker://postgres/15/dev?search_path=public"
+  url = "postgres://localhost:5432/db"
+}
+`, string(dst.Bytes()))
+
+	// Merge schema block with repo, preserving user's mode block.
+	schemaRepoEnvBlock := (&envConfig{
+		URL:    "postgres://localhost:5432/db",
+		DevURL: "docker://postgres/15/dev?search_path=public",
+		Source: "file://schema.hcl",
+		Schema: &schemaConfig{Repo: "roles-repo"},
+	}).AsBlock()
+
+	dst, err = parseConfig(`
+env "roles" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+  }
+}
+`)
+	require.NoError(t, err)
+	require.NoError(t, mergeEnvBlock(dst.Body(), schemaRepoEnvBlock, "roles"))
+	require.Equal(t, `
+env "roles" {
+  schema {
+    mode {
+      roles       = true
+      permissions = true
+    }
+    src = "file://schema.hcl"
+    repo {
+      name = "roles-repo"
+    }
+  }
+  dev = "docker://postgres/15/dev?search_path=public"
+  url = "postgres://localhost:5432/db"
 }
 `, string(dst.Bytes()))
 }


### PR DESCRIPTION
Render atlas_schema.hcl as `env.schema.src` instead of `env.src` and merge schema blocks recursively instead of replacing them wholesale.

This preserves user-defined schema configuration such as `schema.mode`.